### PR TITLE
RFC: match a bunch of functions on Mouze_44

### DIFF
--- a/Source/Kfc_1E0.cpp
+++ b/Source/Kfc_1E0.cpp
@@ -38,7 +38,7 @@ MATCH_FUNC(0x5cbc40)
 void Kfc_30::sub_5CBC40(cool_nash_0x294* a2)
 {
     field_8->sub_4C9970(a2);
-    this->field_4 = this->field_8->field_2C;
+    this->field_4 = this->field_8->field_2C_ped_leader;
 }
 
 STUB_FUNC(0x5cbc60)

--- a/Source/Mouze_44.cpp
+++ b/Source/Mouze_44.cpp
@@ -1,5 +1,7 @@
 #include "Mouze_44.hpp"
 #include "Globals.hpp"
+#include "cool_nash_0x294.hpp"
+#include "enums.h"
 
 EXPORT_VAR Mouze_44 stru_67EF20[20];
 GLOBAL(stru_67EF20, 0x67EF20);
@@ -14,74 +16,189 @@ void Mouze_44::sub_4C8E80()
 {
 }
 
-STUB_FUNC(0x4c8e90)
-cool_nash_0x294** Mouze_44::sub_4C8E90()
+MATCH_FUNC(0x4c8e90)
+void Mouze_44::sub_4C8E90()
 {
-    return 0;
+    field_40_in_use = false;
+    field_38 = 2;
+    field_30 = 0;
+    field_36_count = 0;
+    field_34_count = 0;
+    if (field_2C_ped_leader != NULL)
+    {
+        field_2C_ped_leader->reset_ped_group();
+    }
+    field_2C_ped_leader = NULL;
+    field_0 = 1;
+    field_1 = 0;
+    field_34_count = 0;
+    field_35 = 0;
+
+    for (int i = 0; i < 9; ++i)
+    {
+        if (field_4_ped_list[i] != NULL)
+        {
+            field_4_ped_list[i]->reset_ped_group();
+        }
+        field_4_ped_list[i] = NULL;
+    }
 }
 
 MATCH_FUNC(0x4c8ef0)
 void Mouze_44::sub_4C8EF0()
 {
-    this->field_40 = 0;
+    this->field_40_in_use = 0;
     this->field_38 = 2;
     this->field_30 = 0;
     this->field_36_count = 0;
-    this->field_2C = 0;
+    this->field_2C_ped_leader = NULL;
     this->field_0 = 1;
     this->field_1 = 0;
     this->field_34_count = 0;
     this->field_35 = 0;
     for (s32 i = 0; i < 9; i++)
     {
-        field_4[i] = 0;
+        field_4_ped_list[i] = 0;
     }
 }
 
-STUB_FUNC(0x4c8f20)
+MATCH_FUNC(0x4c8f20)
 void Mouze_44::sub_4C8F20()
 {
+    field_2C_ped_leader->sub_463570(0, 9999);
+    field_2C_ped_leader->sub_463830(0, 9999);
+
+    u8 bVar1 = 0;
+
+    while (bVar1 < field_34_count)
+    {
+        field_4_ped_list[bVar1]->sub_463570(0, 9999);
+        field_4_ped_list[bVar1]->sub_463830(0, 9999);
+        bVar1++;
+    }
 }
 
-STUB_FUNC(0x4c8f90)
-char_type Mouze_44::sub_4C8F90(cool_nash_0x294* pPed)
+MATCH_FUNC(0x4c8f90)
+void Mouze_44::add_ped_to_end_of_list_4C8F90(cool_nash_0x294* pPed)
 {
-    return 0;
+    pPed->sub_463830(0, 9999);
+    pPed->sub_463570(0, 9999);
+    add_ped_to_list_4C9B30(pPed, field_34_count);
+    ++field_34_count;
+    ++field_36_count;
 }
 
-STUB_FUNC(0x4c8fe0)
-void Mouze_44::sub_4C8FE0(cool_nash_0x294* pPed)
+MATCH_FUNC(0x4c8fe0)
+void Mouze_44::replace_leader_4C8FE0(cool_nash_0x294* new_leader)
 {
+    add_ped_to_end_of_list_4C8F90(field_2C_ped_leader);
+    field_2C_ped_leader = new_leader;
+    new_leader->set_ped_group_id(99);
+
+    for(u8 i = 0; i < field_34_count; i++)
+    {
+        field_4_ped_list[i]->sub_463830(0,9999);
+    }
 }
 
-STUB_FUNC(0x4c9040)
+MATCH_FUNC(0x4c9040)
 bool Mouze_44::sub_4C9040()
 {
-    return 0;
+    this->field_36_count = this->field_34_count;
+    if (this->field_2C_ped_leader->field_16C_car != NULL)
+    {
+        this->field_2C_ped_leader->sub_46F9D0();
+        this->field_2C_ped_leader = NULL;
+    }
+
+    u8 bVar2;
+    for (bVar2 = 0; bVar2 < this->field_34_count; bVar2++)
+    {
+        if (this->field_4_ped_list[bVar2]->field_16C_car != NULL)
+        {
+            this->field_4_ped_list[bVar2]->sub_46F9D0();
+            this->field_4_ped_list[bVar2] = NULL;
+        }
+    }
+
+    // Compacting the ped_list
+    for (bVar2 = 0; bVar2 < this->field_34_count; bVar2++)
+    {
+        if (this->field_4_ped_list[bVar2] == NULL)
+        {
+            for(u8 i = bVar2; i < field_34_count; i++)
+            {
+                if (this->field_4_ped_list[i] != NULL)
+                {
+                    this->field_4_ped_list[bVar2] = this->field_4_ped_list[i];
+                    this->field_4_ped_list[i] = NULL;
+                    break;
+                }
+            }
+        }
+    }
+
+    bVar2 = 0;
+    while (this->field_4_ped_list[bVar2] != NULL)
+    {
+        bVar2++;
+    }
+
+    if (bVar2 == 0)
+    {
+        return 0;
+    }
+    return 1;
 }
 
-STUB_FUNC(0x4c9150)
+MATCH_FUNC(0x4c9150)
 char_type Mouze_44::sub_4C9150()
 {
-    return 0;
+    if (field_2C_ped_leader->field_168_game_object == NULL || field_2C_ped_leader->get_field_20e() < 0x28)
+    {
+        return false;
+    }
+
+    for (u8 i = 0; i < this->field_34_count; i++)
+    {
+        if (field_4_ped_list[i]->field_168_game_object == NULL || field_4_ped_list[i]->get_field_20e() < 0x28)
+        {
+            return false;
+        }
+    }
+
+    return true;
 }
 
-STUB_FUNC(0x4c91b0)
-u8 Mouze_44::sub_4C91B0()
+MATCH_FUNC(0x4c91b0)
+void Mouze_44::sub_4C91B0()
 {
-    return 0;
+    for(u8 i = 0; i < field_34_count; i++)
+    {
+        this->field_4_ped_list[i]->unset_bitset_0x04();
+        this->field_4_ped_list[i]->sub_463830(9,9999);
+        this->field_4_ped_list[i]->set_field_14C(this->field_2C_ped_leader);
+    }
 }
 
 STUB_FUNC(0x4c9210)
 bool Mouze_44::sub_4C9210()
 {
-    return 0;
+    // Fails to match
+    return field_2C_ped_leader->has_field_16C_car();
 }
 
-STUB_FUNC(0x4c9220)
+MATCH_FUNC(0x4c9220)
 bool Mouze_44::sub_4C9220()
 {
-    return 0;
+    if (field_2C_ped_leader->get_ped_state1() != ped_state1_enum::ped_entering_a_car)
+    {
+        if (field_2C_ped_leader->get_ped_state1() != ped_state1_enum::unused2)
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 STUB_FUNC(0x4c9240)
@@ -89,15 +206,96 @@ void Mouze_44::sub_4C9240()
 {
 }
 
-STUB_FUNC(0x4c92a0)
-cool_nash_0x294** Mouze_44::sub_4C92A0()
+MATCH_FUNC(0x4c92a0)
+void Mouze_44::sub_4C92A0()
 {
-    return 0;
+    if (this->field_40_in_use == false)
+    {
+        return;
+    }
+
+    field_2C_ped_leader->reset_ped_group();
+    if (this->field_4_ped_list[0] != NULL)
+    {
+        for (u8 bVar4 = 0; bVar4 < this->field_34_count; bVar4++)
+        {
+            cool_nash_0x294* this_00 = this->field_4_ped_list[bVar4];
+            cool_nash_0x294** pppVar1 = this->field_4_ped_list + bVar4;
+            if ((this_00->get_ped_state1() == ped_state1_enum::ped_wasted) || (this_00->field_280 == ped_state1_enum::ped_wasted))
+            {
+                this_00->reset_ped_group();
+            }
+            else
+            {
+                if (this_00->has_field_16C_car())
+                {
+                    this_00->sub_463570(0x22, 9999);
+                    (*pppVar1)->set_field_150_target_objective_car((*pppVar1)->field_16C_car);
+                }
+                else
+                {
+                    this_00->sub_463570(0, 9999);
+                }
+                (*pppVar1)->sub_463830(0, 9999);
+                (*pppVar1)->reset_ped_group();
+                (*pppVar1)->set_ped_type(ped_type_enum::New_Name_2);
+            }
+            (*pppVar1)->field_21C |= 0x400;
+        }
+    }
+    sub_4C8E90();
 }
 
-STUB_FUNC(0x4c93a0)
+MATCH_FUNC(0x4c93a0)
 void Mouze_44::sub_4C93A0()
 {
+    if (field_40_in_use == false)
+    {
+        return;
+    }
+
+    cool_nash_0x294 *ppVar2 = this->field_2C_ped_leader;
+    if ((ppVar2->get_ped_state1() != ped_state1_enum::ped_wasted) &&
+        (ppVar2->field_280 != ped_state1_enum::ped_wasted))
+    {
+        ppVar2->sub_463570(0, 9999);
+        this->field_2C_ped_leader->sub_463830(0, 9999);
+    }
+
+    this->field_2C_ped_leader->reset_ped_group();
+    if (this->field_4_ped_list[0] != NULL)
+    {
+        for (u8 bVar5 = 0; bVar5 < this->field_34_count; bVar5++)
+        {
+            ppVar2 = this->field_4_ped_list[bVar5];
+            cool_nash_0x294 **pppVar1 = this->field_4_ped_list + bVar5;
+            if ((ppVar2->get_ped_state1() == ped_state1_enum::ped_wasted) ||
+                (ppVar2->field_280 == ped_state1_enum::ped_wasted))
+            {
+                ppVar2->reset_ped_group();
+            }
+            else
+            {
+                if (ppVar2->has_field_16C_car() == true)
+                {
+                    ppVar2->sub_463830(0, 9999);
+                    (*pppVar1)->sub_463570(0x22, 9999);
+                    (*pppVar1)->set_field_150_target_objective_car((*pppVar1)->field_16C_car);
+                    (*pppVar1)->reset_ped_group();
+                    (*pppVar1)->set_ped_type(ped_type_enum::New_Name_2);
+                }
+                else
+                {
+                    ppVar2->sub_463570(0, 9999);
+                    (*pppVar1)->sub_463830(0, 9999);
+                    (*pppVar1)->reset_ped_group();
+                    (*pppVar1)->set_ped_type(ped_type_enum::New_Name_2);
+                }
+            }
+        }
+    }
+    sub_4C8E90();
+    return;
 }
 
 STUB_FUNC(0x4c94e0)
@@ -115,16 +313,20 @@ void Mouze_44::sub_4C9970(cool_nash_0x294* a2)
 {
 }
 
-STUB_FUNC(0x4c9b10)
-cool_nash_0x294* Mouze_44::sub_4C9B10(cool_nash_0x294* a2)
+MATCH_FUNC(0x4c9b10)
+void Mouze_44::add_ped_leader_4C9B10(cool_nash_0x294* ptr)
 {
-    return 0;
+    field_2C_ped_leader = ptr;
+    field_2C_ped_leader->set_ped_group(this);
+    field_2C_ped_leader->set_ped_group_id(99);
 }
 
-STUB_FUNC(0x4c9b30)
-cool_nash_0x294* Mouze_44::sub_4C9B30(cool_nash_0x294* ptr, u8 idx)
+MATCH_FUNC(0x4c9b30)
+void Mouze_44::add_ped_to_list_4C9B30(cool_nash_0x294* ptr, u8 idx)
 {
-    return 0;
+    this->field_4_ped_list[idx & 0xff] = ptr;
+    ptr->set_ped_group(this);
+    ptr->set_ped_group_id(idx);
 }
 
 STUB_FUNC(0x4c9b60)
@@ -164,6 +366,123 @@ void Mouze_44::sub_4CA4B0()
 STUB_FUNC(0x4ca5e0)
 void Mouze_44::sub_4CA5E0(u8 idx)
 {
+    /*cool_nash_0x294 *this_00 = field_4_ped_list[idx];
+    if ((this_00->bit_status & 0x8000000) != 0)
+    {
+        return;
+    }
+
+    if (this_00->ped_get_0x258_00403a80() == 8)
+    {
+        if (this_00->ped_get_0x25c_00403a90() == 9)
+        {
+            this_00->sub_436920(0, 9999);
+        }
+    }
+    else
+    {
+        if (this->ped_leader_ptr->ped_is_ped_type_004333a0(ped_type_enum::ped_player) == false)
+        {
+            this_00->field124_0x288 = this->ped_leader_ptr->field124_0x288;
+            this_00->field125_0x28c = this->ped_leader_ptr->field125_0x28c;
+            this_00->field25_0x17c = this->ped_leader_ptr->field25_0x17c;
+        }
+        else
+        {
+            int32_t ped_ocupation = this_00->ped_get_occupation_00403980();
+            if (ped_ocupation != ped_ocupation_enum::drone)
+            {
+                if (ped_ocupation != ped_ocupation_enum::refugees)
+                {
+                    this_00->field124_0x288 = 1;
+                    this_00->field125_0x28c = 2;
+                }
+                else
+                {
+                    this_00->field124_0x288 = 2;
+                    this_00->field125_0x28c = 0;
+                }
+            }
+        }
+
+        ped *ped_leader = this->ped_leader_ptr;
+        if (ped_leader->ped_has_AutoClass30_s1_00403b70())
+        {
+            if (this_00->ped_has_AutoClass30_s1_00403b70())
+            {
+                if ((ped_leader->bit_status & 0x8000000) == 0)
+                {
+                    ped_leader = FUN_00404ad0(param_1);
+                    if (ped_leader != NULL)
+                    {
+                        this_00->FUN_00436920(0x14, 9999);
+                        ped_leader = ped_leader->ped_get_ped_ptr_3_00403af0();
+                        this_00->ped_set_ped_ptr_3_00403ae0(ped_leader);
+                        this_00->ped_FUN_00403950();
+                    }
+                    else
+                    {
+                        if (this_00->ped_get_0x258_00403a80() != 8)
+                        {
+                            if ((this_00->ped_get_occupation_00403980() != ped_ocupation_enum::unknown_13) ||
+                                (this_00->ped_get_0x258_00403a80() != 0x10))
+                            {
+                                FUN_004045d0();
+                            }
+                            if (this->ped_leader_ptr->ped_get_0x25c_00403a90() == 0x3b)
+                            {
+                                this_00->FUN_00436920(0x3b, 9999);
+                                AutoClass21_s1 *pAVar4 = this->ped_leader_ptr->ped_get_AutoClass21_s1_ptr2_00403b10();
+                                this_00->ped_set_AutoClass21_s1_ptr2_00403b00(pAVar4);
+                            }
+                        }
+                        else
+                        {
+                            if (this_00->ped_get_0x25c_00403a90() == 9)
+                            {
+                                this_00->FUN_0043bbc0(0, 9999);
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (this_00->ped_get_0x25c_00403a90() != 0x24)
+                {
+                    this_00->FUN_00436920(0x24, 9999);
+                    this_00->ped_set_AutoClass21_s1_ptr2_00403b00(this_00->AutoClass21_s1_ptr);
+                }
+            }
+        }
+        else
+        {
+            int32_t pVar3;
+            if (this_00->ped_get_0x25c_00403a90() == 9 &&
+                (pVar3 = this_00->ped_get_occupation_00403980(), pVar3 < 0x18 || (0x1b < pVar3)))
+            {
+                ped_leader = this_00->ped_get_ped_ptr_3_00403af0();
+                if ((ped_leader->ped_has_AutoClass21_s1_00403b80()) && (this_00->ped_get_0x258_00403a80() != 8))
+                {
+                    this_00->FUN_0043bbc0(8, 9999);
+                    this_00->FUN_00436920(0, 9999);
+                }
+            }
+        }
+        ped_leader = this_00->ped_get_ped_ptr_3_00403af0();
+        if (ped_leader == NULL)
+        {
+            return;
+        }
+        if (this_00->ped_get_0x25c_00403a90() != 0xb)
+        {
+            return;
+        }
+        if (ped_leader->AutoClass30_s1_ptr == NULL)
+        {
+            this_00->FUN_00436920(0, 9999);
+        }
+    }*/
 }
 
 STUB_FUNC(0x4ca820)

--- a/Source/Mouze_44.hpp
+++ b/Source/Mouze_44.hpp
@@ -9,24 +9,24 @@ class Mouze_44
   public:
     EXPORT void sub_4C8E60();
     EXPORT static void sub_4C8E80();
-    EXPORT cool_nash_0x294** sub_4C8E90();
+    EXPORT void sub_4C8E90();
     EXPORT void sub_4C8EF0();
     EXPORT void sub_4C8F20();
-    EXPORT char_type sub_4C8F90(cool_nash_0x294* pPed);
-    EXPORT void sub_4C8FE0(cool_nash_0x294* pPed);
+    EXPORT void add_ped_to_end_of_list_4C8F90(cool_nash_0x294* pPed);
+    EXPORT void replace_leader_4C8FE0(cool_nash_0x294* pPed);
     EXPORT bool sub_4C9040();
     EXPORT char_type sub_4C9150();
-    EXPORT u8 sub_4C91B0();
+    EXPORT void sub_4C91B0();
     EXPORT bool sub_4C9210();
     EXPORT bool sub_4C9220();
     EXPORT void sub_4C9240();
-    EXPORT cool_nash_0x294** sub_4C92A0();
+    EXPORT void sub_4C92A0();
     EXPORT void sub_4C93A0();
     EXPORT void sub_4C94E0(cool_nash_0x294* a2);
     EXPORT void sub_4C9680(u8 a2);
     EXPORT void sub_4C9970(cool_nash_0x294* a2);
-    EXPORT cool_nash_0x294* sub_4C9B10(cool_nash_0x294* a2);
-    EXPORT cool_nash_0x294* sub_4C9B30(cool_nash_0x294* ptr, u8 idx);
+    EXPORT void add_ped_leader_4C9B10(cool_nash_0x294* a2);
+    EXPORT void add_ped_to_list_4C9B30(cool_nash_0x294* ptr, u8 idx);
     EXPORT char_type sub_4C9B60(cool_nash_0x294* a2);
     EXPORT cool_nash_0x294* sub_4C9ED0();
     EXPORT void sub_4C9F00();
@@ -48,11 +48,11 @@ class Mouze_44
 
     char_type field_0;
     char_type field_1;
-    char_type field_2;
-    char_type field_3;
-    cool_nash_0x294* field_4[9];
+    char_type field_2;    // padding
+    char_type field_3;    // padding
+    cool_nash_0x294* field_4_ped_list[9];
     s32 field_28;
-    cool_nash_0x294* field_2C;
+    cool_nash_0x294* field_2C_ped_leader;
     s32 field_30;
     u8 field_34_count;
     char_type field_35;
@@ -60,7 +60,7 @@ class Mouze_44
     char_type field_37;
     s32 field_38;
     s32 field_3C;
-    char_type field_40;
+    char_type field_40_in_use;
     char_type field_41;
     char_type field_42;
     char_type field_43;

--- a/Source/cool_nash_0x294.cpp
+++ b/Source/cool_nash_0x294.cpp
@@ -236,10 +236,22 @@ void cool_nash_0x294::sub_45C4B0()
     */
 }
 
-STUB_FUNC(0x45c500)
-s32 cool_nash_0x294::sub_45C500(s32 a2)
+MATCH_FUNC(0x45c500)
+void cool_nash_0x294::sub_45C500(s32 a2)
 {
-    return 0;
+    if (this->field_278 != ped_state1_enum::ped_fall_on_ground)
+    {
+        if (a2 == ped_state1_enum::ped_fall_on_ground)
+        {
+            this->field_280 = this->field_278;
+        }
+        this->field_278 = a2;
+        return;
+    }
+    if (a2 != ped_state1_enum::ped_fall_on_ground)
+    {
+        this->field_280 = a2;
+    }
 }
 
 STUB_FUNC(0x45c540)
@@ -1037,19 +1049,22 @@ void cool_nash_0x294::sub_46D460(char_type a2)
 {
 }
 
-STUB_FUNC(0x46db60)
+MATCH_FUNC(0x46db60)
 void cool_nash_0x294::sub_46DB60()
 {
+    sub_46D460(0);
 }
 
-STUB_FUNC(0x46db70)
+MATCH_FUNC(0x46db70)
 void cool_nash_0x294::sub_46DB70()
 {
+    sub_46D460(1);
 }
 
-STUB_FUNC(0x46db80)
+MATCH_FUNC(0x46db80)
 void cool_nash_0x294::sub_46DB80()
 {
+    sub_46D460(2);
 }
 
 STUB_FUNC(0x46df50)
@@ -1082,10 +1097,53 @@ u8 cool_nash_0x294::sub_46E200(u8 a2)
     return 0;
 }
 
-STUB_FUNC(0x46ef00)
+MATCH_FUNC(0x46ef00)
 u8 cool_nash_0x294::get_wanted_star_count_46EF00()
 {
-    return 0;
+    short cVar1 = this->field_20A_wanted_points;
+    if (cVar1 < cop_level_ped_enum::cop_6_stars)
+    {
+        if (cVar1 < cop_level_ped_enum::cop_5_stars)
+        {
+            if (cVar1 < cop_level_ped_enum::cop_4_stars)
+            {
+                if (cVar1 < cop_level_ped_enum::cop_3_stars)
+                {
+                    if (cVar1 < cop_level_ped_enum::cop_2_stars)
+                    {
+                        if (cVar1 < cop_level_ped_enum::cop_1_stars)
+                        {
+                            return cop_level_enum::cops_0;
+                        }
+                        else
+                        {
+                            return cop_level_enum::cops_1;
+                        }
+                    }
+                    else
+                    {
+                        return cop_level_enum::cops_2;
+                    }
+                }
+                else
+                {
+                    return cop_level_enum::cops_3;
+                }
+            }
+            else
+            {
+                return cop_level_enum::cops_4;
+            }
+        }
+        else
+        {
+            return cop_level_enum::cops_5;
+        }
+    }
+    else
+    {
+        return cop_level_enum::cops_6;
+    }
 }
 
 MATCH_FUNC(0x46ef40)

--- a/Source/cool_nash_0x294.hpp
+++ b/Source/cool_nash_0x294.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstdio>
 #include "Function.hpp"
 #include "Marz_1D7E.hpp"
+#include "enums.h"
 #include "fix16.hpp"
 
 class angry_lewin_0x85C;
@@ -48,7 +50,7 @@ class cool_nash_0x294
     EXPORT void sub_45C350(gmp_map_zone* a2);
     EXPORT s32 sub_45C410();
     EXPORT void sub_45C4B0();
-    EXPORT s32 sub_45C500(s32 a2);
+    EXPORT void sub_45C500(s32 a2);
     EXPORT s32 sub_45C540(s32 a2);
     EXPORT void sub_45C5A0();
     EXPORT void sub_45C5C0();
@@ -218,6 +220,57 @@ class cool_nash_0x294
     EXPORT s32 sub_470300();
     EXPORT s32 sub_470F00();
     EXPORT cool_nash_0x294* sub_470F90(cool_nash_0x294* pSrc);
+
+    void reset_ped_group()
+    {
+        field_164_ped_group = NULL;
+        field_23C = 0;
+    }
+
+    void set_ped_group(Mouze_44 *ptr)
+    {
+        field_164_ped_group = ptr;
+    }
+
+    void set_ped_group_id(s8 param_1)
+    {
+        field_23C = param_1;
+    }
+
+    u16 get_field_20e() const
+    {
+        return field_20e;
+    }
+
+    char has_field_16C_car() const
+    {
+        return field_16C_car != NULL;
+    }
+
+    s32 get_ped_state1() const
+    {
+        return field_278;
+    }
+
+    void set_field_14C(cool_nash_0x294* pSrc)
+    {
+		field_14C = pSrc;
+    }
+
+    void unset_bitset_0x04()
+	{
+        field_21C &= ~ped_bit_status_enum::k_ped_0x4;
+	}
+
+    void set_field_150_target_objective_car(Car_BC *ptr)
+    {
+        field_150_target_objective_car = ptr;
+    }
+
+    void set_ped_type(s32 param_1)
+    {
+        field_238 = param_1;
+    }
 
     Marz_3 field_0[100];
     s16 field_12C;

--- a/Source/enums.h
+++ b/Source/enums.h
@@ -1,0 +1,415 @@
+#ifndef ENUMS_H
+#define ENUMS_H
+
+namespace car_manager_car_type_enum {
+enum
+{
+    New_Name = 0,
+    New_Name_1 = 1,
+    New_Name_2 = 2,
+    New_Name_3 = 3,
+    ambulance = 4,
+    firetruck = 5,
+    police_cars = 6
+};
+// static_assert(sizeof(car_manager_car_type_enum) == 4);
+} // namespace car_manager_car_type_enum
+namespace car_model_enum {
+enum
+{
+    alfa = 0,
+    allard = 1,
+    amdb4 = 2,
+    apc = 3,
+    bank_van = 4,
+    bmw = 5,
+    boxcar = 6,
+    boxtruck = 7,
+    bug = 8,
+    CAR9 = 9,
+    BUICK = 10,
+    BUS = 11,
+    COPCAR = 12,
+    DART = 13,
+    EDSEL = 14,
+    CAR15 = 15,
+    FIAT = 16,
+    FIRETRUK = 17,
+    GRAHAM = 18,
+    GT24640 = 19,
+    CAR20 = 20,
+    GTRUCK = 21,
+    GUNJEEP = 22,
+    HOTDOG = 23,
+    HOTDOG_D1 = 24,
+    HOTDOG_D2 = 25,
+    HOTDOG_D3 = 26,
+    ICECREAM = 27,
+    ISETLIMO = 28,
+    ISETTA = 29,
+    JEEP = 30,
+    JEFFREY = 31,
+    LIMO = 32,
+    LIMO2 = 33,
+    MEDICAR = 34,
+    MERC = 35,
+    MESSER = 36,
+    MIURA = 37,
+    MONSTER = 38,
+    MORGAN = 39,
+    MORRIS = 40,
+    PICKUP = 41,
+    RTYPE = 42,
+    CAR43 = 43,
+    SPIDER = 44,
+    SPRITE = 45,
+    STINGRAY = 46,
+    STRATOS = 47,
+    STRATOSB = 48,
+    STRIPETB = 49,
+    STYPE = 50,
+    STYPECAB = 51,
+    SWATVAN = 52,
+    T2000GT = 53,
+    TANK = 54,
+    TANKER = 55,
+    TAXI = 56,
+    TBIRD = 57,
+    TOWTRUCK = 58,
+    TRAIN = 59,
+    TRAINCAB = 60,
+    TRAINFB = 61,
+    TRANCEAM = 62,
+    TRUKCAB1 = 63,
+    TRUKCAB2 = 64,
+    TRUKCONT = 65,
+    TRUKTRNS = 66,
+    TVVAN = 67,
+    VAN = 68,
+    VESPA = 69,
+    VTYPE = 70,
+    WBTWIN = 71,
+    WRECK0 = 72,
+    WRECK1 = 73,
+    WRECK2 = 74,
+    WRECK3 = 75,
+    WRECK4 = 76,
+    WRECK5 = 77,
+    WRECK6 = 78,
+    WRECK7 = 79,
+    WRECK8 = 80,
+    WRECK9 = 81,
+    XK120 = 82,
+    ZCX5 = 83,
+    EDSELFBI = 84,
+    HOTDOG_D4 = 85,
+    KRSNABUS = 86,
+    none = 87
+};
+// static_assert(sizeof(car_model_enum) == 4);
+} // namespace car_model_enum
+
+namespace cop_level_enum {
+enum cop_level_enum
+{
+    cops_0 = 0,
+    cops_1 = 1,
+    cops_2 = 2,
+    cops_3 = 3,
+    cops_4 = 4,
+    cops_5 = 5,
+    cops_6 = 6,
+};
+}
+
+namespace cop_level_ped_enum {
+enum
+{ /* The cop level stored in the PED */
+  cop_0_stars = 0,
+  cop_1_stars = 600,
+  cop_2_stars = 1600,
+  cop_3_stars = 3000,
+  cop_4_stars = 5000,
+  cop_5_stars = 8000,
+  cop_6_stars = 12000
+};
+// static_assert(sizeof(cop_level_ped_enum) == 2);
+} // namespace cop_level_ped_enum
+
+namespace gmp_zone_type_enum {
+enum
+{
+    general_purpose = 0,
+    navigation = 1,
+    traffic_light = 2,
+    unused1 = 3,
+    unused2 = 4,
+    arrow_blocker = 5,
+    railway_station_platform = 6,
+    bus_stop_pavement = 7,
+    general_trigger = 8,
+    unused3 = 9,
+    information = 10,
+    railway_station_entry_point = 11,
+    railway_station_exit_point = 12,
+    railway_stop_point = 13,
+    gang = 14,
+    local_navigation = 15,
+    restart = 16,
+    unused4 = 17,
+    unused5 = 18,
+    unsued6 = 19,
+    arrest_restart = 20
+};
+// static_assert(sizeof(gmp_zone_type_enum) == 4);
+} // namespace gmp_zone_type_enum
+
+namespace palette_types_enum {
+enum
+{
+    wrong_type = 0,
+    tiles = 1,
+    sprites = 2,
+    car_remaps = 3,
+    ped_remaps = 4,
+    code_obj_remaps = 5,
+    map_obj_remaps = 6,
+    user_remaps = 7,
+    font_remaps = 8,
+};
+// static_assert(sizeof(palette_types_enum) == 4);
+} // namespace palette_types_enum
+
+namespace ped_bit_status_enum {
+enum
+{
+    k_ped_0x1 = 0x00000001,
+    k_ped_0x4 = 0x00000004,
+    k_ped_has_weapon = 0x00000800,
+    k_ped_in_flames = 0x01000000,
+    k_ped_invisible = 0x02000000,
+    k_ped_0x400_0000 = 0x04000000,
+    k_ped_electro_fingers = 0x40000000,
+};
+// static_assert(sizeof(ped_bit_status_enum) == 0x4);
+} // namespace ped_bit_status_enum
+
+namespace ped_major_state {
+enum
+{
+    ped_major_New_Name = 0,
+    ped_major_walking = 1,
+    ped_major_New_Name_1 = 2,
+    ped_major_New_Name_2 = 3,
+    ped_major_staying = 4,
+    ped_major_driving = 5,
+    ped_major_entering_a_car = 6,
+    ped_major_getting_out_a_car = 7
+};
+// static_assert(sizeof(ped_major_state) == 0x1);
+} // namespace ped_major_state
+
+namespace ped_ocupation_enum {
+enum
+{ /* The ocupation that a PED can have */
+  player = 0,
+  empty = 1,
+  unknown_1 = 2,
+  dummy = 3,
+  unknown_2 = 4,
+  driver = 5,
+  unknown_3 = 6,
+  unknown_4 = 7,
+  unknown_5 = 8,
+  unknown_6 = 9,
+  driver_2 = 10,
+  unknown_7 = 11,
+  unknown_8 = 12,
+  unknown_9 = 13,
+  psycho = 14,
+  mugger = 15,
+  car_thief = 16,
+  bank_robber = 17,
+  criminal = 18,
+  unknown_10 = 19,
+  unknown_11 = 20,
+  unknown_12 = 21,
+  elvis = 22,
+  unknown_13 = 23,
+  police = 24,
+  swat = 25,
+  fbi = 26,
+  army_army = 27,
+  guard = 28,
+  unknown_14 = 29,
+  unknown_15 = 30,
+  unknown_16 = 31,
+  guard_against_player = 32,
+  criminal_type_1 = 33,
+  criminal_type_2 = 34,
+  special_groups_member = 35,
+  tank_driver = 36,
+  unknown_17 = 37,
+  fireman = 38,
+  road_block_tank_man = 39,
+  unknown_18 = 40,
+  drone = 41,
+  unknown_19 = 42,
+  stand_still_bloke = 43,
+  elvis_leader = 44,
+  refugees = 45,
+  any_law_enforcement = 46,
+  any_emergency_service_man = 47,
+  any_gang_member = 48,
+  any_elvis = 49,
+  driver_3 = 50,
+  no_occupation = 51,
+};
+// static_assert(sizeof(ped_ocupation_enum) == 0x4);
+} // namespace ped_ocupation_enum
+
+namespace ped_remap_enum {
+enum
+{
+    ped_remap_blue_police = 0,
+    ped_remap_green_police = 1,
+    ped_remap_red_police = 2,
+    ped_remap_yellow_police = 3,
+    ped_remap_khaki_police = 4,
+    ped_remap_red_head_redneck = 5,
+    ped_remap_blond_head_redneck = 6,
+    ped_remap_yellow_scientist = 7,
+    ped_remap_zaibatsu = 8,
+    ped_remap_kristna = 9,
+    ped_remap_russian = 10,
+    ped_remap_lonny = 11,
+    ped_remap_elvis = 12,
+    ped_remap_yakuza = 13,
+    ped_remap_fireman = 14,
+    ped_remap_green_shorts = 15,
+    ped_remap_medic = 16,
+    ped_remap_mugger = 17,
+    ped_remap_blue_dummy = 18,
+    ped_remap_light_blue_dummy = 19,
+    ped_remap_tshirt_and_shorts_dummy = 20,
+    ped_remap_short_sleeve = 21,
+    ped_remap_prison_uniform = 22,
+    ped_remap_hulk1_normal = 23,
+    ped_remap_hulk2_green = 24,
+    ped_remap_player = 25,
+    ped_remap_naked_dummy = 26,
+};
+// static_assert(sizeof(ped_remap_enum) == 0x1);
+} // namespace ped_remap_enum
+
+namespace ped_state1_enum {
+enum
+{
+    ped_walking = 0,
+    unused1 = 1,
+    ped_going_to_car = 2,
+    ped_entering_a_car = 3,
+    ped_getting_out_a_car = 4,
+    unused2 = 5,
+    unused3 = 6,
+    ped_staying = 7,
+    ped_fall_on_ground = 8,
+    ped_wasted = 9,
+    ped_driving = 10,
+};
+// static_assert(sizeof(ped_state1_enum) == 0x4);
+} // namespace ped_state1_enum
+
+namespace ped_state2_enum {
+enum
+{
+    ped2_walking = 0,
+    New_Name = 1,
+    New_Name_1 = 2,
+    New_Name_2 = 3,
+    ped2_following_a_car = 4,
+    New_Name_3 = 5,
+    ped2_entering_a_car = 6,
+    ped2_getting_out_a_car = 7,
+    New_Name_4 = 8,
+    New_Name_5 = 9,
+    ped2_driving = 10,
+    ped2_staying = 14,
+    ped_unknown = 15
+};
+// static_assert(sizeof(ped_state2_enum) == 0x4);
+} // namespace ped_state2_enum
+
+namespace ped_type_enum {
+enum
+{
+    New_Name = 0,
+    New_Name_1 = 1,
+    ped_player = 2,
+    New_Name_2 = 3,
+    ped_elvis = 4,
+    New_Name_3 = 5,
+    ped_car_thief = 6,
+};
+// static_assert(sizeof(ped_type_enum) == 0x4);
+} // namespace ped_type_enum
+
+namespace spec_surface_type_enum {
+enum
+{
+    spec_grass = 2,
+    spec_road_special = 3,
+    spec_water = 4,
+    spec_electrified = 5,
+    spec_electrified_platform = 6,
+    spec_wood_floor = 7,
+    spec_metal_floor = 8,
+    spec_metal_wall = 9,
+    spec_grass_dirt_wall = 10,
+};
+// static_assert(sizeof(spec_surface_type_enum) == 4);
+} // namespace spec_surface_type_enum
+
+namespace sprite_types_enum {
+enum
+{
+    unknown_0 = 0, // At least in the function sprite_FUN_004b9aa0, but don't know what represents.
+    unknown_1 = 1, // At least in the function sprite_FUN_004b9aa0, but don't know what represents.
+    car = 2,
+    ped = 3,
+    code_obj1 = 4,
+    map_obj = 5,
+    user = 6,
+    font = 7,
+    code_obj2 = 8,
+};
+// static_assert(sizeof(sprite_types_enum) == 4);
+} // namespace sprite_types_enum
+
+namespace weapon_type {
+enum
+{
+    pistol = 0,
+    smg = 1,
+    rocket = 2,
+    shocker = 3,
+    molotov = 4,
+    grenade = 5,
+    shotgun = 6,
+    electro_batton = 7,
+    flamethrower = 8,
+    silence_smg = 9,
+    dual_pistol = 10,
+    car_bomb = 15,
+    oil_stain = 16,
+    car_mines = 17,
+    car_smg = 18,
+    tank_main_gun = 19,
+    fire_truck_gun = 20,
+    fire_truck_flamethrower = 21,
+    army_gun_jeep = 22,
+};
+// static_assert(sizeof(weapon_type) == 0x4);
+} // namespace weapon_type
+
+#endif // ENUMS_H


### PR DESCRIPTION
I have made a bunch of matches, and some code changes.

The code is a bit of a mess as I am using helper functions, and those still have old names.

I would be good to have some feedback on how to deal with the enums.
and the helper functions that don't show up on the version 10.5 but exist on the 9.6f.

