### PR TITLE
Add functions for class Ang16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ set(gta2_lib_src
   Source/BitSet32.hpp
   Source/fix16.hpp
   Source/fix16.cpp
+  Source/ang16.hpp
+  Source/ang16.cpp
   Source/error.hpp
   Source/error.cpp
   Source/memory.hpp

--- a/Source/Garox_2B00.hpp
+++ b/Source/Garox_2B00.hpp
@@ -2,6 +2,7 @@
 
 #include "Function.hpp"
 #include "fix16.hpp"
+#include "ang16.hpp"
 #include <wchar.h>
 
 class cool_nash_0x294;

--- a/Source/ang16.cpp
+++ b/Source/ang16.cpp
@@ -1,0 +1,41 @@
+#include "Function.hpp"
+#include "ang16.hpp"
+#include <cmath>
+
+MATCH_FUNC(0x406C20)
+void Ang16::sub_406C20()
+{
+    Normalize();
+}
+
+MATCH_FUNC(0x409300)
+Ang16* Ang16::sub_409300(Ang16* a2, s32 a3)
+{
+    rValue = a2->rValue;
+    Normalize();
+    return this;
+}
+
+MATCH_FUNC(0x409340)
+Ang16* Ang16::sub_409340(Ang16* pRet, Ang16* toSub)
+{
+    pRet->rValue = rValue - toSub->rValue;
+    pRet->Normalize();
+    return pRet;
+}
+
+MATCH_FUNC(0x4516B0)
+Ang16* Ang16::sub_4516B0(s32* a2, s32 a3)
+{
+    rValue = *a2 >> 14;
+    Normalize();
+    return this;
+}
+
+MATCH_FUNC(0x482740)
+Ang16* Ang16::sub_482740(Ang16* a1, s32* a2)
+{
+    a1->rValue = (s32)*a2 / 71;
+    a1->Normalize();
+    return a1;
+}

--- a/Source/ang16.hpp
+++ b/Source/ang16.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "Function.hpp"
+
+class Ang16
+{
+  public:
+    //   Ang16  and  Ang16
+    bool operator>(const Ang16& other)
+    {
+        return rValue > other.rValue;
+    }
+
+    bool operator<(const Ang16& other)
+    {
+        return rValue < other.rValue;
+    }
+
+    bool operator>=(const Ang16& other)
+    {
+        return rValue >= other.rValue;
+    }
+
+    bool operator<=(const Ang16& other)
+    {
+        return rValue <= other.rValue;
+    }
+
+    Ang16 operator-=(const Ang16& other)
+    {
+        rValue -= other.rValue;
+        return *this;
+    }
+
+    Ang16 operator+=(const Ang16& other)
+    {
+        rValue += other.rValue;
+        return *this;
+    }
+
+    Ang16 operator=(const Ang16& other)
+    {
+        rValue = other.rValue;
+        return *this;
+    }
+
+    //   Ang16  and  const int
+
+    bool operator>(const s32 other)
+    {
+        return rValue > other;
+    }
+
+    bool operator<(const s32 other)
+    {
+        return rValue < other;
+    }
+
+    bool operator>=(const s32 other)
+    {
+        return rValue >= other;
+    }
+
+    bool operator<=(const s32 other)
+    {
+        return rValue <= other;
+    }
+
+    Ang16 operator-=(const s32 other)
+    {
+        rValue -= other;
+        return *this;
+    }
+
+    Ang16 operator+=(const s32 other)
+    {
+        rValue += other;
+        return *this;
+    }
+
+    Ang16 operator<<(const s32 other)
+    {
+        rValue = rValue << other;
+        return *this;
+    }
+
+    Ang16 operator>>(const s32 other)
+    {
+        rValue = rValue >> other;
+        return *this;
+    }
+
+    Ang16 operator*(const s32 other)
+    {
+        rValue *= other;
+        return *this;
+    }
+
+    Ang16 operator=(const s32 other)
+    {
+        rValue = other;
+        return *this;
+    }
+
+    Ang16 operator-(const s32 other)
+    {
+        rValue -= other;
+        return *this;
+    }
+
+    inline s16 Float()
+    {
+        return rValue << 14;
+    }
+
+    EXPORT void sub_406C20();
+    inline void Normalize()
+    {
+        for (; *this < 0; *this += 1440)
+        {
+            ;
+        }
+        for (; *this >= 1440; *this -= 1440)
+        {
+            ;
+        }
+    };
+
+    EXPORT Ang16* sub_409300(Ang16* a2, s32 a3);
+    EXPORT Ang16* sub_409340(Ang16* pRet, Ang16* toSub);
+    EXPORT Ang16* sub_482740(Ang16* a1, s32* a2);
+    EXPORT Ang16* sub_4516B0(s32* a2, s32 a3);
+
+    Ang16() : rValue(0)
+    {
+    }
+
+    s16 rValue;
+};

--- a/Source/fix16.hpp
+++ b/Source/fix16.hpp
@@ -2,18 +2,6 @@
 
 #include "Function.hpp"
 
-// TODO: Move
-class Ang16
-{
-  public:
-    // inline 0x40E590
-    Ang16() : field_0(0)
-    {
-    }
-
-    s16 field_0;
-};
-
 class Fix16
 {
   public:


### PR DESCRIPTION
These functions shows in IDA as being part from Fix16, but they won't match using it. They've matched with Ang16 though, which uses type s16 instead of s32.