### PR TITLE
Monster 808

### DIFF
--- a/Source/Monster_808.cpp
+++ b/Source/Monster_808.cpp
@@ -28,6 +28,15 @@ GLOBAL(found_open_brackets_67626C, 0x67626C);
 EXPORT_VAR s32 line_number_676258;
 GLOBAL(line_number_676258, 0x676258);
 
+EXPORT_VAR u32 processed_output_676250;
+GLOBAL(processed_output_676250, 0x676250);
+
+EXPORT_VAR s32 output_size_675F90;
+GLOBAL(output_size_675F90, 0x675F90);
+
+EXPORT_VAR u8* output_ptr_675F98;
+GLOBAL(output_ptr_675F98, 0x675F98);
+
 STUB_FUNC(0x454680)
 void Monster_48::sub_454680()
 {
@@ -122,6 +131,21 @@ char* __stdcall Monster_808::parse_gci_file_430A30(void* input,
                                                    u32* next_position)
 {
     return NULL;
+}
+
+MATCH_FUNC(0x430e60)
+s32 __stdcall Monster_808::sub_430E60(void* param_1, u32 param_2)
+{
+    processed_output_676250 += param_2;
+    if (processed_output_676250 > output_size_675F90)
+    {
+        return -12;
+    }
+
+    memcpy(output_ptr_675F98, param_1, param_2);
+
+    output_ptr_675F98 = output_ptr_675F98 + param_2;
+    return 0;
 }
 
 MATCH_FUNC(0x430EC0)

--- a/Source/Monster_808.cpp
+++ b/Source/Monster_808.cpp
@@ -37,9 +37,16 @@ GLOBAL(output_size_675F90, 0x675F90);
 EXPORT_VAR u8* output_ptr_675F98;
 GLOBAL(output_ptr_675F98, 0x675F98);
 
-STUB_FUNC(0x454680)
+EXPORT_VAR Fix16 DAT_5e5514;
+GLOBAL(DAT_5e5514, 0x5e5514);
+
+EXPORT_VAR Fix16 DAT_5e54a0;
+GLOBAL(DAT_5e54a0, 0x5e54a0);
+
+MATCH_FUNC(0x454680)
 void Monster_48::sub_454680()
 {
+    field_4_mass = field_4_mass * (DAT_5e54a0 + DAT_5e5514);
 }
 
 MATCH_FUNC(0x430b10)

--- a/Source/Monster_808.cpp
+++ b/Source/Monster_808.cpp
@@ -340,16 +340,13 @@ void Monster_808::sub_454850()
     }
 }
 
-STUB_FUNC(0x4549c0)
+MATCH_FUNC(0x4549c0)
 void Monster_808::sub_4549C0()
 {
-    // stupid meme function - doing some strange backwards looping
-    car_info_container* container = gGtx_0x106C_703DD4->field_5C_cari;
-    Monster_48* pIter = field_804_raw_data;
-    for (s32 i = 0; i < container->field_400_count; i++)
+    u32 number_of_cars = gGtx_0x106C_703DD4->get_number_of_cars();
+    for (u32 i = 0; i < number_of_cars; i++)
     {
-        pIter->sub_454680();
-        pIter++;
+        field_804_raw_data[i].sub_454680();
     }
 }
 

--- a/Source/Monster_808.cpp
+++ b/Source/Monster_808.cpp
@@ -43,6 +43,9 @@ GLOBAL(DAT_5e5514, 0x5e5514);
 EXPORT_VAR Fix16 DAT_5e54a0;
 GLOBAL(DAT_5e54a0, 0x5e54a0);
 
+EXPORT_VAR Fix16 DAT_6761A4;
+GLOBAL(DAT_6761A4, 0x6761a4);
+
 MATCH_FUNC(0x454680)
 void Monster_48::sub_454680()
 {
@@ -239,6 +242,36 @@ s32 __stdcall Monster_808::StrToInt_430FA0(const char* param_1, s32* param_2)
         iVar5 = iVar5 * 10;
     }
 
+    return 0;
+}
+
+MATCH_FUNC(0x431000)
+s32 __stdcall Monster_808::FloatStrToFix16_431000(char* param_1, Fix16 &param_2)
+{
+    param_2 = DAT_6761A4;
+    bool bVar2 = false;
+    s32 iVar6 = 1;
+    s32 iVar5 = strlen(param_1);
+
+    while (--iVar5 >= 0)
+    {
+        char cVar1 = param_1[iVar5];
+        if (cVar1 < '0' || '9' < cVar1)
+        {
+            if (cVar1 != '.' || bVar2)
+            {
+                return -11;
+            }
+            param_2.mValue /= iVar6;
+            iVar6 = 1;
+            bVar2 = true;
+        }
+        else
+        {
+            param_2.mValue += (cVar1 - 0x30) * iVar6 * 0x4000;
+            iVar6 = iVar6 * 10;
+        }
+    }
     return 0;
 }
 

--- a/Source/Monster_808.hpp
+++ b/Source/Monster_808.hpp
@@ -78,6 +78,7 @@ class Monster_808
     static s32 __stdcall HexStr2Int_430EC0(const char* param_1, s32* param_2);
     static s32 __stdcall HexStr2Int_430F30(const char* param_1, s16* param_2);
     static s32 __stdcall StrToInt_430FA0(const char* param_1, s32* param_2);
+    static s32 __stdcall FloatStrToFix16_431000(char *param_1, Fix16 &param_2);
     static s32 __stdcall StrToInt_431080(const char* param_1, s16* param_2);
 
     Monster_2C* field_0_ptr_array[256];

--- a/Source/Monster_808.hpp
+++ b/Source/Monster_808.hpp
@@ -74,6 +74,7 @@ class Monster_808
                                                  size_t output_size,
                                                  u32* next_position);
     static s32 __stdcall sub_430b10(char* param_1);
+    static s32 __stdcall sub_430E60(void *param_1, u32 param_2);
     static s32 __stdcall HexStr2Int_430EC0(const char* param_1, s32* param_2);
     static s32 __stdcall HexStr2Int_430F30(const char* param_1, s16* param_2);
     static s32 __stdcall StrToInt_430FA0(const char* param_1, s32* param_2);

--- a/Source/fix16.cpp
+++ b/Source/fix16.cpp
@@ -23,29 +23,17 @@ Fix16& Fix16::FromU16_4AE970(u16 a2)
     return *this;
 }
 
-
-MATCH_FUNC(0x408680)
-Fix16 Fix16::operator*(const Fix16& in)
-{
-    Fix16 ret;
-    ret.mValue = (mValue * (__int64)in.mValue) >> 14;
-    return ret;
-}
-
 MATCH_FUNC(0x4086A0)
 Fix16 Fix16::operator-()
 {
-    Fix16 ret;
-    ret.mValue = -mValue;
-    return ret;
+    return Fix16(-mValue, 0);
 }
 
 MATCH_FUNC(0x408660)
 Fix16 Fix16::operator+(const Fix16& rhs) const
 {
-    Fix16 ret;
-    ret.mValue = mValue + rhs.mValue;
-    return ret;
+    s32 value = mValue + rhs.mValue;
+    return Fix16(value, 0);
 }
 
 MATCH_FUNC(0x44E540)
@@ -66,27 +54,24 @@ Fix16 Fix16::Max_44E540(Fix16& pLhs, Fix16& pRhs)
 MATCH_FUNC(0x436A20)
 Fix16 Fix16::operator/(const Fix16& in)
 {
-    Fix16 result;
-    result = ((__int64)mValue << 14) / in.mValue;
-    return result;
+    s32 value = ((__int64)mValue << 14) / in.mValue;
+    return Fix16(value, 0);
 }
 
 MATCH_FUNC(0x436A50)
 Fix16 Fix16::Abs_436A50(Fix16& a2)
 {
-    Fix16 result;
-    result.mValue = a2.mValue;
+    s32 value = a2.mValue;
     if (a2.mValue <= 0)
     {
-        result.mValue = -a2.mValue;
+        value = -a2.mValue;
     }
-    return result;
+    return Fix16(value, 0);
 }
 
 MATCH_FUNC(0x436A70)
 Fix16 Fix16::SquareRoot_436A70(Fix16& a2)
 {
-    Fix16 result;
-    result.mValue = sqrt(a2.AsDouble()) * 16384.0f;
-    return result;
+    s32 value = sqrt(a2.AsDouble()) * 16384.0f;
+    return Fix16(value, 0);
 }

--- a/Source/fix16.hpp
+++ b/Source/fix16.hpp
@@ -18,9 +18,8 @@ class Fix16
 
     Fix16 operator-(const Fix16& in)
     {
-        Fix16 t;
-        t.mValue = mValue - in.mValue;
-        return t;
+        s32 value = mValue - in.mValue;
+        return Fix16(value, 0);
     }
 
     Fix16 operator-=(const Fix16& other)
@@ -31,15 +30,20 @@ class Fix16
 
     Fix16 operator+(const Fix16& in)
     {
-        Fix16 t;
-        t.mValue = mValue + in.mValue;
-        return t;
+        s32 value = mValue + in.mValue;
+        return Fix16(value, 0);
     }
 
     Fix16 operator+=(const Fix16& other)
     {
         mValue += other.mValue;
         return *this;
+    }
+
+    Fix16 operator*(const Fix16& in) const
+    {
+        s32 value = (s32)((mValue * (__int64)in.mValue) >> 14);
+        return Fix16(value, 0);
     }
 
     bool operator>(const Fix16& other)
@@ -86,6 +90,10 @@ class Fix16
     {
     }
 
+    Fix16(s32 value, u8) : mValue(value)
+    {
+    }
+
     explicit Fix16(f32 v) : mValue(static_cast<s32>(v * 16384.0))
     {
     }
@@ -102,11 +110,7 @@ class Fix16
     EXPORT Fix16 Max_44E540(Fix16& pLhs, Fix16& pRhs);
     EXPORT Fix16 Abs_436A50(Fix16& a2);
     EXPORT Fix16 SquareRoot_436A70(Fix16& a2);
-
-    EXPORT Fix16 operator*(const Fix16& in);
-
     EXPORT Fix16 operator-();
-
     EXPORT Fix16 operator+(const Fix16& rhs) const;
     EXPORT Fix16 operator/(const Fix16& in);
 


### PR DESCRIPTION
This PR has some changes to Fix16.
The code now looks more like the version 9.6f with the constructors.
I had to make them because I wasn't able to match Monster_48::sub_454680 and the operator*

The downside is that it loses one match, as the operator* needs to be in the header and wasn't able to find a way to add the MATCH_FUNC tag.

Is there a way to do it?