### PR TITLE
Lot of Fix16 fixes, some matches in miss2_0x11C

### DIFF
--- a/Source/BitSet32.hpp
+++ b/Source/BitSet32.hpp
@@ -2,16 +2,26 @@
 
 #include "types.hpp"
 
-class BitSet32 {
+class BitSet32
+{
   public:
-    void clear_bit(int bit) {
+    void clear_bit(int bit)
+    {
         m_var &= ~(1 << bit);
+    }
+    void set_bit(int bit)
+    {
+        m_var |= (1 << bit);
+    }
+    bool check_bit(s32 bit)
+    {
+        return m_var & (1 << bit);
     }
     BitSet32& operator=(u32 value)
     {
         m_var = value;
         return *this;
     }
-  private:
+
     u32 m_var;
 };

--- a/Source/char.cpp
+++ b/Source/char.cpp
@@ -87,7 +87,7 @@ Char_C::~Char_C()
 }
 
 MATCH_FUNC(0x470a50)
-cool_nash_0x294* Char_C::sub_470A50(s32 xpos, s32 ypos, s32 zpos, u8 remap, s16 rotation)
+cool_nash_0x294* Char_C::sub_470A50(Fix16 xpos, Fix16 ypos, Fix16 zpos, u8 remap, s16 rotation)
 {
     Char_203AC* v6 = gChar_203AC_6787B8;
     cool_nash_0x294* pPed = gChar_203AC_6787B8->field_0;

--- a/Source/char.hpp
+++ b/Source/char.hpp
@@ -145,7 +145,7 @@ class Char_C
     EXPORT void sub_4703F0();
     EXPORT Char_C();
     EXPORT ~Char_C();
-    EXPORT cool_nash_0x294* sub_470A50(s32 xpos, s32 ypos, s32 zpos, u8 remap, s16 a6);
+    EXPORT cool_nash_0x294* sub_470A50(Fix16 xpos, Fix16 ypos, Fix16 zpos, u8 remap, s16 a6);
     EXPORT cool_nash_0x294* sub_470B00(Car_BC* a2);
     EXPORT cool_nash_0x294* sub_470BA0(Car_BC* a1, s32 a2);
     EXPORT cool_nash_0x294* sub_470CC0(Car_BC* a2);

--- a/Source/cool_nash_0x294.cpp
+++ b/Source/cool_nash_0x294.cpp
@@ -463,7 +463,7 @@ Char_8* cool_nash_0x294::sub_45C7F0(Car_BC* pCar)
 }
 
 STUB_FUNC(0x45c830)
-char_type cool_nash_0x294::sub_45C830(s32 xpos, s32 ypos, s32 zpos)
+char_type cool_nash_0x294::sub_45C830(Fix16 xpos, Fix16 ypos, Fix16 zpos)
 {
     return 0;
 }

--- a/Source/cool_nash_0x294.hpp
+++ b/Source/cool_nash_0x294.hpp
@@ -59,7 +59,7 @@ class cool_nash_0x294
     EXPORT s32 sub_45C730(Car_BC* a2);
     EXPORT void sub_45C7A0(Car_BC* a2);
     EXPORT Char_8* sub_45C7F0(Car_BC* a2);
-    EXPORT char_type sub_45C830(s32 xpos, s32 ypos, s32 zpos);
+    EXPORT char_type sub_45C830(Fix16 xpos, Fix16 ypos, Fix16 zpos);
     EXPORT s16* sub_45C900(s16* a2);
     EXPORT s32* sub_45C920(s32* a2);
     EXPORT s16* sub_45C960(s16* a2);

--- a/Source/fix16.hpp
+++ b/Source/fix16.hpp
@@ -82,6 +82,11 @@ class Fix16
         return mValue >> 14;
     }
 
+    inline void FromInt(s32 a1)
+    {
+        mValue = a1 << 14;
+    }
+
     float ToFloat() const
     {
         return mValue * 0.0000610351562f;
@@ -107,7 +112,7 @@ class Fix16
     inline Fix16 ConcatenateWord(Fix16 a2)
     {
         Fix16 result;
-        result.mValue = mValue + ( a2.mValue & 0xFFFFC000 );
+        result.mValue = mValue + (a2.mValue & 0xFFFFC000);
         return result;
     }
 

--- a/Source/map_0x370.cpp
+++ b/Source/map_0x370.cpp
@@ -963,25 +963,25 @@ Fix16* Map_0x370::sub_4E4D40(Fix16* a2, Fix16 x_pos, Fix16 y_pos, Fix16 z_pos)
     return a2;
 }
 
-MATCH_FUNC(0x4E4E50)
-s32* Map_0x370::sub_4E4E50(s32* a2, s32 a3, s32 a4, s32 a5)
+STUB_FUNC(0x4E4E50)     //  DAMN reg swap    https://decomp.me/scratch/aQODE
+Fix16* Map_0x370::sub_4E4E50(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5)
 {
-    s32 v5;
+    Fix16 v5;
     gmp_block_info* block_4DFE10;
     s8 v10;
     u8 v11;
     gmp_block_info* v12;
     s8 field_B_slope_type;
     u8 v14;
-    s32 v16;
+    Fix16 v16;
 
-    for (v5 = a5; v5 < a5 + dword_6F6110.mValue; v5 = dword_6F6110.mValue + (v5 & 0xFFFFC000))
+    for (v5.mValue = a5.mValue; v5.mValue < a5.mValue + dword_6F6110.mValue; v5.mValue = dword_6F6110.mValue + (v5.mValue & 0xFFFFC000))
     {
-        block_4DFE10 = Map_0x370::get_block_4DFE10(a3 >> 14, a4 >> 14, v5 >> 14);
+        block_4DFE10 = Map_0x370::get_block_4DFE10(a3.ToInt(), a4.ToInt(), v5.ToInt());
         gBlockInfo0_6F5EB0 = block_4DFE10;
         if (!block_4DFE10 || (v10 = block_4DFE10->field_B_slope_type, (v10 & 3) == 0))
         {
-            v12 = Map_0x370::get_block_4DFE10(a3 >> 14, a4 >> 14, (v5 - dword_6F6110.mValue) >> 14);
+            v12 = Map_0x370::get_block_4DFE10(a3.ToInt(), a4.ToInt(), (v5 - dword_6F6110).ToInt());
             gBlockInfo0_6F5EB0 = v12;
             if (v12)
             {
@@ -991,7 +991,7 @@ s32* Map_0x370::sub_4E4E50(s32* a2, s32 a3, s32 a4, s32 a5)
                     v14 = field_B_slope_type & 0xFC;
                     if (v14 <= 0 || v14 >= 0xB4u)
                     {
-                        *a2 = v5;
+                        a2->mValue = v5.mValue;
                         return a2;
                     }
                 }
@@ -1004,11 +1004,11 @@ s32* Map_0x370::sub_4E4E50(s32* a2, s32 a3, s32 a4, s32 a5)
             {
                 if (v11 < 0xB4u)
                 {
-                    v16 = v5 & 0xFFFFC000;
+                    v16.mValue = v5.mValue & 0xFFFFC000;
                     Map_0x370::sub_4E5BF0(a3, a4, &v16);
                     if (v16 >= v5)
                     {
-                        *a2 = v16;
+                        a2->mValue = v16.mValue;
                         return a2;
                     }
                 }
@@ -1016,7 +1016,7 @@ s32* Map_0x370::sub_4E4E50(s32* a2, s32 a3, s32 a4, s32 a5)
         }
     }
     v5 = a5;
-    *a2 = v5;
+    a2->mValue = v5.mValue;
     return a2;
 }
 

--- a/Source/map_0x370.cpp
+++ b/Source/map_0x370.cpp
@@ -1180,14 +1180,14 @@ gmp_block_info* Map_0x370::sub_4E6360(s32 a2, s32 a3, s32* a4)
 }
 
 MATCH_FUNC(0x4E6400)
-s32* Map_0x370::sub_4E6400(s32* a2, Fix16 a3, Fix16 a4, Fix16 a5)
+Fix16* Map_0x370::sub_4E6400(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5)
 {
     Fix16 v5;
     Fix16 v6;
     Fix16 v7;
     gmp_block_info* block_4DFE10;
     u8 v9;
-    s32 v10;
+    Fix16 v10;
     u8 v13;
 
     v5 = a5;
@@ -1198,15 +1198,15 @@ s32* Map_0x370::sub_4E6400(s32* a2, Fix16 a3, Fix16 a4, Fix16 a5)
         || (v9 = block_4DFE10->field_B_slope_type, (v13 = v9 & 0xFC) <= 0)
         || v13 >= 0xB4
         || (v9 & 3) == 0
-        || (v10 = v5.mValue & 0xFFFFC000, Map_0x370::sub_4E5BF0(v7.mValue, v6.mValue, (s32*)&v10),
-         v10 > v5.mValue) )
+        || (v10.mValue = v5.mValue & 0xFFFFC000, Map_0x370::sub_4E5BF0(v7, v6, &v10),
+         v10 > v5))
     {
         s32 v14 = v5.ToInt() - 1;
         gmp_block_info* v11 = Map_0x370::sub_4E6360(v7.ToInt(), v6.ToInt(), &v14);
         gBlockInfo0_6F5EB0 = v11;
         if (!v11)
         {
-            *a2 = 0x4000;
+            a2->mValue = 0x4000;
             return a2;
         }
         s8 field_B_slope_type = v11->field_B_slope_type;
@@ -1215,14 +1215,15 @@ s32* Map_0x370::sub_4E6400(s32* a2, Fix16 a3, Fix16 a4, Fix16 a5)
             && v13 < 0xB4u
             && (field_B_slope_type & 3) != 0 )
         {
-            v10 = v14 << 14;
-            Map_0x370::sub_4E5BF0(v7.mValue, v6.mValue, &v10);
-        } else {
-            v10 = (v14 + 1) << 14;
+            v10.FromInt(v14);
+            Map_0x370::sub_4E5BF0(v7, v6, &v10);
         }
-        
+        else
+        {
+            v10.FromInt(v14 + 1);
+        }
     }
-    *a2 = v10;
+    a2->mValue = v10.mValue;
     return a2;
 }
 

--- a/Source/map_0x370.cpp
+++ b/Source/map_0x370.cpp
@@ -1112,7 +1112,7 @@ Fix16* Map_0x370::sub_4E5B60(Fix16* a2, Fix16 x_pos, Fix16 y_pos)
 }
 
 STUB_FUNC(0x4E5BF0)
-char_type Map_0x370::sub_4E5BF0(s32 a2, s32 a3, s32* a4)
+char_type Map_0x370::sub_4E5BF0(Fix16 a2, Fix16 a3, Fix16* a4)
 {
     return 0;
 }
@@ -1210,7 +1210,6 @@ Fix16* Map_0x370::sub_4E6400(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5)
             return a2;
         }
         s8 field_B_slope_type = v11->field_B_slope_type;
-        
         if ( ( v13 = field_B_slope_type & 0xFCu ) > 0 
             && v13 < 0xB4u
             && (field_B_slope_type & 3) != 0 )

--- a/Source/map_0x370.cpp
+++ b/Source/map_0x370.cpp
@@ -1228,12 +1228,12 @@ Fix16* Map_0x370::sub_4E6400(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5)
 }
 
 MATCH_FUNC(0x4E6510)
-s32* Map_0x370::sub_4E6510(s32* a2, Fix16 a3, Fix16 a4)
+Fix16* Map_0x370::sub_4E6510(Fix16* a2, Fix16 a3, Fix16 a4)
 {
     Fix16 v4;
     Fix16 v5;
     gmp_block_info* v7;
-    s32 v10;
+    Fix16 v10;
     u32 v6;
     
     v4 = a3;
@@ -1242,7 +1242,7 @@ s32* Map_0x370::sub_4E6510(s32* a2, Fix16 a3, Fix16 a4)
     gBlockInfo0_6F5EB0 = v7;
     if (!v7)
     {
-        *a2 = 0;
+        a2->mValue = 0;
         return a2;
     }
     else
@@ -1253,15 +1253,15 @@ s32* Map_0x370::sub_4E6510(s32* a2, Fix16 a3, Fix16 a4)
             && v13 < 0xB4 
             && (field_B_slope_type & 3) != 0)
         {
-            v10 = v6 << 14;
-            Map_0x370::sub_4E5BF0(v4.mValue, v5.mValue, &v10);
+            v10.FromInt(v6);
+            Map_0x370::sub_4E5BF0(v4, v5, &v10);
         }
         else
         {
-            v10 = (v6 + 1) << 14;
+            v10.FromInt(v6 + 1);
         }
     }
-    *a2 = v10;
+    a2->mValue = v10.mValue;
     return a2;
 }
 

--- a/Source/map_0x370.cpp
+++ b/Source/map_0x370.cpp
@@ -1063,10 +1063,10 @@ char_type Map_0x370::sub_4E5640(s32 a1, s32 a2, s32 a3, s32 a4, s32 a5, s32 a6, 
 }
 
 MATCH_FUNC(0x4E5B60)
-s32* Map_0x370::sub_4E5B60(s32* a2, s32 a3, s32 a4)
+Fix16* Map_0x370::sub_4E5B60(Fix16* a2, Fix16 x_pos, Fix16 y_pos)
 {
-    s32 v4;
-    s32 v5;
+    Fix16 v4;
+    Fix16 v5;
     gmp_block_info* v7;
     char_type field_B_slope_type;
 
@@ -1074,18 +1074,18 @@ s32* Map_0x370::sub_4E5B60(s32* a2, s32 a3, s32 a4)
 
     s32 v6;
 
-    s32 v9;
+    Fix16 v9;
 
-    v4 = a3;
-    v5 = a4;
+    v4 = x_pos;
+    v5 = y_pos;
 
     //  >> 14 means divide by 16384
-    v7 = Map_0x370::sub_4E4C30(a3 >> 14, a4 >> 14, (u32*)&v6); //  get the highest non-air block at (a3,a4)
+    v7 = Map_0x370::sub_4E4C30(x_pos.ToInt(), y_pos.ToInt(), (u32*)&v6); //  get the highest block at (x_pos,y_pos)?
     gBlockInfo0_6F5EB0 = v7;
 
     if (!v7)
     {
-        *a2 = 0;
+        a2->mValue = 0;
         return a2;
     }
     else
@@ -1099,14 +1099,14 @@ s32* Map_0x370::sub_4E5B60(s32* a2, s32 a3, s32 a4)
             && ((u8)field_B_slope_type & 0xFCu) < 0xB4u //  < 10110100 = it's a ramp
             && ((u8)field_B_slope_type & 3) != 0) //  (bits 0-1) != 0 means it's not an air block
         {
-            v9 = v6 << 14; //  multiply by 16384
+            v9.FromInt(v6);
             Map_0x370::sub_4E5BF0(v4, v5, &v9); //  get the Z position based on the slope angle?
         }
         else
         {
-            v9 = (v6 + 1) << 14; //  multiply by 16384
+            v9.FromInt(v6 + 1);
         }
-        *a2 = v9;
+        a2->mValue = v9.mValue;
         return a2;
     }
 }

--- a/Source/map_0x370.cpp
+++ b/Source/map_0x370.cpp
@@ -915,55 +915,52 @@ gmp_block_info* Map_0x370::sub_4E4CB0(s32 a2, s32 a3, s32* a4)
 }
 
 MATCH_FUNC(0x4E4D40)
-s32* Map_0x370::sub_4E4D40(s32* a2, s32 a3, s32 a4, s32 a5)
+Fix16* Map_0x370::sub_4E4D40(Fix16* a2, Fix16 x_pos, Fix16 y_pos, Fix16 z_pos)
 {
-    s32 v5;
-    s32 v6;
+    Fix16 v4;
+    Fix16 v5;
+    Fix16 v6;
     gmp_block_info* block_4DFE10;
     char_type v9;
-    s32 v10;
+    Fix16 v10;
     gmp_block_info* v11;
-    s32* result;
     char_type field_B_slope_type;
 
     u8 v13;
-    s32 v4;
     s32 v14;
 
-    v5 = a5;
-    v6 = a4;
-    v4 = a3;
-    if ((a5 & 0x3FFF) == dword_6F610C || (block_4DFE10 = Map_0x370::get_block_4DFE10(a3 >> 14, a4 >> 14, a5 >> 14)) == 0 ||
+    v5 = z_pos;
+    v6 = y_pos;
+    v4 = x_pos;
+    if ((z_pos.mValue & 0x3FFF) == dword_6F610C ||
+        (block_4DFE10 = Map_0x370::get_block_4DFE10(x_pos.ToInt(), y_pos.ToInt(), z_pos.ToInt())) == 0 ||
         (v9 = block_4DFE10->field_B_slope_type, (v13 = v9 & 0xFCu) <= 0) //  or it's a flat block
         || v13 >= 0xB4 //  or it's not a ramp
         || (v9 & 3) == 0 //  or it's a air block
-        || (v10 = v5 & 0xFFFFC000, Map_0x370::sub_4E5BF0(a3, v6, &v10), v10 > v5))
+        || (v10.mValue = v5.mValue & 0xFFFFC000, Map_0x370::sub_4E5BF0(x_pos, v6, &v10), v10 > v5))
     {
-        v14 = (v5 >> 14) - 1;
-        v11 = Map_0x370::sub_4E4CB0(v4 >> 14, v6 >> 14, &v14);
+        v14 = v5.ToInt() - 1;
+        v11 = Map_0x370::sub_4E4CB0(v4.ToInt(), v6.ToInt(), &v14);
         gBlockInfo0_6F5EB0 = v11;
         if (!v11)
         {
-            result = a2;
-            *a2 = dword_6F6110.mValue;
-            return result;
+            a2->mValue = dword_6F6110.mValue;
+            return a2;
         }
         field_B_slope_type = v11->field_B_slope_type;
 
         if ((v13 = field_B_slope_type & 0xFC) > 0 //  it's not a flat block
             && v13 < 0xB4 && (field_B_slope_type & 3) != 0)
         {
-            v10 = v14 << 14;
-            Map_0x370::sub_4E5BF0(a3, v6, &v10);
-            result = a2;
-            *a2 = v10;
-            return result;
+            v10.FromInt(v14);
+            Map_0x370::sub_4E5BF0(x_pos, v6, &v10);
+            a2->mValue = v10.mValue;
+            return a2;
         }
-        v10 = (++v14) << 14;
+        v10.FromInt(++v14);
     }
-    result = a2;
-    *a2 = v10;
-    return result;
+    a2->mValue = v10.mValue;
+    return a2;
 }
 
 MATCH_FUNC(0x4E4E50)

--- a/Source/map_0x370.hpp
+++ b/Source/map_0x370.hpp
@@ -398,8 +398,8 @@ class Map_0x370
     EXPORT gmp_block_info* sub_4E4BB0(s32 a2, s32 a3, u32* a4);
     EXPORT gmp_block_info* sub_4E4C30(s32 a2, s32 a3, u32* a4);
     EXPORT gmp_block_info* sub_4E4CB0(s32 a2, s32 a3, s32* a4);
-    EXPORT s32* sub_4E4D40(s32* a2, s32 a3, s32 a4, s32 a5);
-    EXPORT s32* sub_4E4E50(s32* a2, s32 a3, s32 a4, s32 a5);
+    EXPORT Fix16* sub_4E4D40(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5);
+    EXPORT Fix16* sub_4E4E50(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5);
     EXPORT s32* sub_4E4F40(s32* a2, s32 a3, s32 a4, s32 a5);
     EXPORT s32* sub_4E5050(s32* a2, s32 a3, s32 a4, s32 a5, u8* a6);
     EXPORT char_type sub_4E5170(s32 a2, s32 a3, s32 a4);
@@ -407,13 +407,13 @@ class Map_0x370
     EXPORT char_type sub_4E5300(s32 a2, s32 a3, s32 a4, s32 a5);
     EXPORT char_type sub_4E5480(s32 a2, s32 a3, s32 a4, s32 a5, s32* a6);
     EXPORT char_type sub_4E5640(s32 a1, s32 a2, s32 a3, s32 a4, s32 a5, s32 a6, s32 a7, s32 a8, s32 a9);
-    EXPORT s32* sub_4E5B60(s32* a2, s32 a3, s32 a4);
-    EXPORT char_type sub_4E5BF0(s32 a2, s32 a3, s32* a4);
+    EXPORT Fix16* sub_4E5B60(Fix16* a2, Fix16 a3, Fix16 a4);
+    EXPORT char_type sub_4E5BF0(Fix16 a2, Fix16 a3, Fix16* a4);
     EXPORT s16 sub_4E6190(s32 x, s32 y, s32 z, s32 a5, char_type a6);
     EXPORT gmp_block_info* sub_4E62D0(s32 a2, s32 a3, u32* a4);
     EXPORT gmp_block_info* sub_4E6360(s32 a2, s32 a3, s32* a4);
-    EXPORT s32* sub_4E6400(s32* a2, Fix16 a3, Fix16 a4, Fix16 a5);
-    EXPORT s32* sub_4E6510(s32* a2, Fix16 a3, Fix16 a4);
+    EXPORT Fix16* sub_4E6400(Fix16* a2, Fix16 a3, Fix16 a4, Fix16 a5);
+    EXPORT Fix16* sub_4E6510(Fix16* a2, Fix16 a3, Fix16 a4);
     EXPORT s16 sub_4E65A0(s32 a2, s32 a3, s32* a4, char_type a5, char_type a6);
     EXPORT s32 sub_4E6660(s32* a2, s32* a3, s32* a4, s32 a5);
     EXPORT s32 sub_4E7190(s32* a2, s32* a3, s32* a4, s32 a5);

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -880,9 +880,11 @@ void miss2_0x11C::SCRCMD_DISABLE_THREAD_50ABC0()
 {
 }
 
-STUB_FUNC(0x50abf0)
+MATCH_FUNC(0x50abf0)
 void miss2_0x11C::SCRCMD_ENABLE_THREAD_50ABF0()
 {
+    miss2_0x11C::sub_50A9E0(gBasePtr_6F8070[1].field_0_cmd_this);
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 STUB_FUNC(0x50ac20)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -875,9 +875,11 @@ void miss2_0x11C::sub_50A9E0(u16 idx)
 {
 }
 
-STUB_FUNC(0x50abc0)
+MATCH_FUNC(0x50abc0)
 void miss2_0x11C::SCRCMD_DISABLE_THREAD_50ABC0()
 {
+    miss2_0x11C::sub_505790(gBasePtr_6F8070[1].field_0_cmd_this);
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50abf0)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -41,10 +41,10 @@ GLOBAL(dword_6F791C, 0x6F791C);
 EXPORT_VAR Ang16 word_6F8044;
 GLOBAL(word_6F8044, 0x6F8044);
 
-EXPORT_VAR s32 dword_6F7924;
+EXPORT_VAR Fix16 dword_6F7924;
 GLOBAL(dword_6F7924, 0x6F7924);
 
-EXPORT_VAR s32 dword_6F7570;
+EXPORT_VAR Fix16 dword_6F7570;
 GLOBAL(dword_6F7570, 0x6F7570);
 
 EXPORT_VAR s16 dword_6F804C;
@@ -134,8 +134,8 @@ void miss2_0x11C::SCRCMD_PLAYER_PED_503A20(SCR_PLAYER_PED* pCmd)
         cool_nash_0x294* pPed;
         if (gfrosty_pasteur_6F8060->field_C1E2C)
         {
-            s32 weird_y = (dword_6F76DC.ConcatenateWord(dword_6F7920)).mValue;
-            s32 weird_x = (dword_6F75F0.ConcatenateWord(dword_6F791C)).mValue;
+            Fix16 weird_y = dword_6F76DC.ConcatenateWord(dword_6F7920);
+            Fix16 weird_x = dword_6F75F0.ConcatenateWord(dword_6F791C);
 
             pPed = gChar_C_6787BC->sub_470A50(weird_x,
                                             weird_y, 
@@ -147,7 +147,7 @@ void miss2_0x11C::SCRCMD_PLAYER_PED_503A20(SCR_PLAYER_PED* pCmd)
         {
             if (pCmd->field_C_pos.field_8_z == dword_6F7570) //  dword_6F7570 is 255.0
             {
-                s32 temp_z;
+                Fix16 temp_z;
                 //  Calculate the real Z position at (X,Y) based on the map
                 pCmd->field_C_pos.field_8_z =
                     *gMap_0x370_6F6268->sub_4E5B60(&temp_z,
@@ -216,7 +216,7 @@ void miss2_0x11C::SCRCMD_CHAR_DECSET_2D_3D_503FB0(SCR_CHAR_DATA_DEC* pCmd, SCR_P
 
     if (pCmd->field_C_pos.field_8_z == dword_6F7570)
     {
-        s32 temp_z;
+        Fix16 temp_z;
         pCmd->field_C_pos.field_8_z = *gMap_0x370_6F6268->sub_4E5B60(&temp_z,
                                                                     pCmd->field_C_pos.field_0_x,
                                                                     pCmd->field_C_pos.field_4_y);

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -260,9 +260,10 @@ cool_nash_0x294* miss2_0x11C::sub_504110(SCR_CHAR_OBJECTIVE* a1, SCR_POINTER* a2
 {
     (a2->field_8_char)->sub_463570(a1->field_A_objective, 9999);
     cool_nash_0x294* v2 = a2->field_8_char;
-    s32 v3 = v2->field_21C;
-    v3 &= ~0x400u; // TODO: Maybe BitSet32
-    v2->field_21C = v3;
+    BitSet32 v3;
+    v3 = v2->field_21C;
+    v3.clear_bit(10);
+    v2->field_21C = v3.m_var;
     return v2;
 }
 

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -773,18 +773,18 @@ void miss2_0x11C::sub_50A200()
 MATCH_FUNC(0x50a3e0)
 void miss2_0x11C::sub_50A3E0()
 {
-    SCR_CHAR_OBJECTIVE* v1;
+    SCR_CHAR_OBJ3* v1;
     SCR_POINTER* pCmd;
 
-    v1 = (SCR_CHAR_OBJECTIVE*)gBasePtr_6F8070;
+    v1 = (SCR_CHAR_OBJ3*)gBasePtr_6F8070;
     pCmd = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
     miss2_0x11C::sub_504110((SCR_CHAR_OBJECTIVE*)gBasePtr_6F8070, pCmd);
 
     if (pCmd->field_8_char)
     {
-        (pCmd->field_8_char)->field_1DC_objective_target_x = v1->field_C_pos.field_0_x;
-        (pCmd->field_8_char)->field_1E0_objective_target_y = v1->field_C_pos.field_4_y;
-        (pCmd->field_8_char)->field_1E4_objective_target_z = v1->field_C_pos.field_8_z;
+        (pCmd->field_8_char)->field_1DC_objective_target_x = v1->field_C_pos.field_0_x.mValue; //  TODO: May be Fix16 in cool_nash
+        (pCmd->field_8_char)->field_1E0_objective_target_y = v1->field_C_pos.field_4_y.mValue;
+        (pCmd->field_8_char)->field_1E4_objective_target_z = v1->field_C_pos.field_8_z.mValue;
 
         (pCmd->field_8_char)->field_21C &= ~0x400u; // TODO: Maybe BitSet32
     }

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Function.hpp"
+#include "fix16.hpp"
 
 class cool_nash_0x294;
 class Maccies_2C;
@@ -19,9 +20,9 @@ struct SCR_CMD_HEADER
 
 struct SCR_XYZ_f
 {
-    s32 field_0_x;
-    s32 field_4_y;
-    s32 field_8_z;
+    Fix16 field_0_x;
+    Fix16 field_4_y;
+    Fix16 field_8_z;
 };
 
 struct SCR_PLAYER_PED

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -94,7 +94,6 @@ struct SCR_CHAR_OBJECTIVE : SCR_CMD_HEADER
             u16 field_C_second_item_idx; //  SCR_SET_CHAR_OBJ2
             u16 field_E_variant;
         };
-        SCR_XYZ_f field_C_pos; //  SCR_SET_CHAR_OBJ3
         struct
         {
             u16 field_C_car_idx; //  SET_CHAR_OBJ_FOLLOW
@@ -102,6 +101,13 @@ struct SCR_CHAR_OBJECTIVE : SCR_CMD_HEADER
             s32 field_12_offset;
         };
     };
+};
+
+struct SCR_CHAR_OBJ3 : SCR_CMD_HEADER
+{
+    u16 field_8_char_idx;
+    s16 field_A_objective;
+    SCR_XYZ_f field_C_pos; //  SCR_SET_CHAR_OBJ3
 };
 
 struct SCR_IF_JUMP : SCR_CMD_HEADER


### PR DESCRIPTION
match miss2_0x11C::SCRCMD_ENABLE_THREAD_50ABF0
match miss2_0x11C::SCRCMD_DISABLE_THREAD_50ABC0
Add "FromInt" method to Fix16
Add some useful methods to BitSet32
fix BitSet32 in miss2_0x11C::sub_504110

Replace by Fix16 in SCR_XYZ_f
Replace by Fix16 in 0x470A50 and 0x45C830
Replace by Fix16 in 0x503A20 and 0x503FB0
Replace by Fix16 in Map_0x370::sub_4E4D40
Replace by Fix16 in Map_0x370::sub_4E4E50 
Replace by Fix16 in Map_0x370::sub_4E5B60
Replace by Fix16 in Map_0x370::sub_4E6400
Replace by Fix16 in Map_0x370::sub_4E6510
Replace by Fix16 in Map_0x370::sub_4E5BF0
Update map_0x370.hpp, Fix16 changes

Remove default ctor from union in SCR_CHAR_OBJECTIVE
Replace by SCR_CHAR_OBJ3 in sub_50A3E0