### PR TITLE
Build changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
 project (decomp)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
 ENABLE_LANGUAGE(ASM_MASM)
 
 SET(CMAKE_WARN_VS6 CACHE BOOL OFF)
@@ -231,14 +233,6 @@ set(gta2_lib_src
   Source/Weapon_30.cpp
 )
 
-# turn off intrinsic functions so we actually get a call to strcpy, enable stdcall calling convention
-# else static methods don't match (and I doubt they manually annotated them with __stdcall)
-set_source_files_properties(Source/Network_20324.cpp PROPERTIES COMPILE_FLAGS "/Oi- /Gz")
-
-set_source_files_properties(Source/miss2_0x11C.cpp PROPERTIES COMPILE_FLAGS "/GX-")
-set_source_files_properties(Source/sharp_bose_0x54.cpp PROPERTIES COMPILE_FLAGS "/GX-")
-
-
 # global include dirs
 include_directories(Source)
 include_directories(${decomp_SOURCE_DIR})
@@ -263,12 +257,11 @@ add_library (gta2_dll_imports SHARED ${gta2_lib_src} Source/WinMainProxy.cpp)
 target_compile_definitions(gta2_dll_imports PRIVATE IMPORT_VARS EXPORT_FUNCS _CRT_SECURE_NO_WARNINGS _CRT_NON_CONFORMING_SWPRINTFS)
 target_link_libraries(gta2_dll_imports gta2_dll_exports mss32 Winmm ${dplay_libs})
 
-
 add_library(HookLoader SHARED 
-Source/HookLoader.cpp
-Source/3rdParty/Detours/src/detours.cpp
-Source/3rdParty/Detours/src/disasm.cpp
-"Source/3rdParty/Manual-DLL-Loader/Source/Manual Loader/Loader.cpp"
+    Source/HookLoader.cpp
+    Source/3rdParty/Detours/src/detours.cpp
+    Source/3rdParty/Detours/src/disasm.cpp
+    "Source/3rdParty/Manual-DLL-Loader/Source/Manual Loader/Loader.cpp"
 )
 target_compile_definitions(HookLoader PRIVATE DETOURS_X86 DETOURS_32BIT)
 
@@ -281,55 +274,6 @@ add_executable (decomp_main WIN32
     resources.rc)
 target_link_libraries(decomp_main mss32 gta2_lib ${dplay_libs})
 
-#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS")
-
-# NOICF is required because skip_ovly_5AAE20 and skip_psxt_5AAE30 have identical bodies and the linker will make them one and the same
-# however the real binary does have 2 copies. NOREF keeps functions that are not yet called so we can diff the content against the original.
-if (${MSVC_VERSION} GREATER 1200)
-set (CMAKE_EXE_LINKER_FLAGS "/MAP:output.map /OPT:NOICF,NOREF /SAFESEH:NO" )
-else()
-set (CMAKE_EXE_LINKER_FLAGS "/MAP:output.map /OPT:NOICF,NOREF" )
-endif()
-set (CMAKE_SHARED_LINKER_FLAGS "/OPT:NOICF,NOREF")
-
-set(CompilerFlags
-        CMAKE_CXX_FLAGS
-        CMAKE_CXX_FLAGS_DEBUG
-        CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_C_FLAGS
-        CMAKE_C_FLAGS_DEBUG
-        CMAKE_C_FLAGS_RELEASE
-        )
-
-if (${MSVC_VERSION} EQUAL 1200)
-foreach(CompilerFlag ${CompilerFlags})
-  string(REPLACE "/MD" "/ML /W3 /GX" ${CompilerFlag} "${${CompilerFlag}}")
-endforeach()
-
-foreach(CompilerFlag ${CompilerFlags})
-  string(REPLACE "/Zi" "/Z7" ${CompilerFlag} "${${CompilerFlag}}")
-endforeach()
-
-foreach(CompilerFlag ${CompilerFlags})
-  string(REPLACE "/Ob2" "" ${CompilerFlag} "${${CompilerFlag}}")
-endforeach()
-
-foreach(CompilerFlag ${CompilerFlags})
-  string(REPLACE "/GR" "/EHsc" ${CompilerFlag} "${${CompilerFlag}}")
-endforeach()
-endif()
-
-message(STATUS "${MSVC_VERSION}=${${MSVC_VERSION}}")
-
-if (${MSVC_VERSION} GREATER 1200)
-   SET ( CMAKE_SHARED_LINKER_FLAGS /MANIFEST:NO )
-
-   if (NOT DEFINED ENV{CI})
-       add_custom_command(TARGET decomp_main POST_BUILD
-           COMMAND python build.py
-           WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-           COMMENT "Running build.py (VC6 build)")
-   endif()
-endif()
-
-#install (TARGETS decomp_main DESTINATION bin)
+if(${MSVC})
+    include(cmake/vc6.cmake)
+endif ()

--- a/Source/Function.hpp
+++ b/Source/Function.hpp
@@ -5,43 +5,56 @@
 // Pattern: 0x90, 0x90 0xB8 [addr bytes x4] 0xB8 [status bytes x4] 0x90 0x90
 #define FUNC_MARKER_ASM(addr, status) __asm nop __asm nop __asm mov eax, addr __asm mov eax, status __asm nop __asm nop
 
-#define MATCH_FUNC(addr)                   \
-    __declspec(naked) void Marker_##addr() \
-    {                                      \
-        FUNC_MARKER_ASM(addr, 1)           \
-    }
-#define STUB_FUNC(addr)                    \
-    __declspec(naked) void Marker_##addr() \
-    {                                      \
-        FUNC_MARKER_ASM(addr, 0)           \
-    }
+#if defined(_MSC_VER)
+    #define MATCH_FUNC(addr)                   \
+        __declspec(naked) void Marker_##addr() \
+        {                                      \
+            FUNC_MARKER_ASM(addr, 1)           \
+        }
+    #define STUB_FUNC(addr)                    \
+        __declspec(naked) void Marker_##addr() \
+        {                                      \
+            FUNC_MARKER_ASM(addr, 0)           \
+        }
+
+    #if defined(EXPORT_FUNCS)
+        #define EXPORT __declspec(dllexport)
+    #else
+        #define EXPORT
+    #endif
+
+    #if defined(EXPORT_VARS) || defined(IMPORT_VARS)
+        #if defined(EXPORT_VARS)
+            #define EXPORT_VAR __declspec(dllexport)
+        #elif defined(IMPORT_VARS)
+            #define EXPORT_VAR __declspec(dllimport)
+        #endif
+    #else
+        #define EXPORT_VAR
+    #endif
+#else
+    #define MATCH_FUNC(addr)
+    #define STUB_FUNC(addr)
+    #define EXPORT
+    #define EXPORT_VAR
+    #define __stdcall
+#endif
+
+#if defined(_MSC_VER)
+    #if _MSC_VER > 1200
+        #define GTA2_ASSERT_SIZEOF_ALWAYS(structureName, expectedSize) \
+            static_assert(sizeof(structureName) == expectedSize, "sizeof(" #structureName ") must be " #expectedSize);
+    #else
+        #define GTA2_ASSERT_SIZEOF_ALWAYS(structureName, expectedSize) \
+            typedef int static_assert_##structureName[sizeof(structureName) == expectedSize ? 1 : -1];
+    #endif
+#else
+    #define GTA2_ASSERT_SIZEOF_ALWAYS(structureName, expectedSize) \
+        static_assert(sizeof(structureName) == expectedSize, "sizeof(" #structureName ") must be " #expectedSize);
+#endif
 
 #define GTA2_COUNTOF(x) (sizeof(x) / sizeof(*(x)))
 #define GTA2_COUNTOF_S(x) ((s32)GTA2_COUNTOF(x))
-
-#if defined(EXPORT_FUNCS)
-    #define EXPORT __declspec(dllexport)
-#else
-    #define EXPORT
-#endif
-
-#if defined(EXPORT_VARS) || defined(IMPORT_VARS)
-    #if defined(EXPORT_VARS)
-        #define EXPORT_VAR __declspec(dllexport)
-    #elif defined(IMPORT_VARS)
-        #define EXPORT_VAR __declspec(dllimport)
-    #endif
-#else
-    #define EXPORT_VAR
-#endif
-
-#if _MSC_VER > 1200
-    #define GTA2_ASSERT_SIZEOF_ALWAYS(structureName, expectedSize) \
-        static_assert(sizeof(structureName) == expectedSize, "sizeof(" #structureName ") must be " #expectedSize);
-#else
-    #define GTA2_ASSERT_SIZEOF_ALWAYS(structureName, expectedSize) \
-        typedef int static_assert_##structureName[sizeof(structureName) == expectedSize ? 1 : -1];
-#endif
 
 #define GTA2_DELETE_AND_NULL(x) \
     delete x;                   \

--- a/cmake/vc6.cmake
+++ b/cmake/vc6.cmake
@@ -1,0 +1,57 @@
+
+
+# turn off intrinsic functions so we actually get a call to strcpy, enable stdcall calling convention
+# else static methods don't match (and I doubt they manually annotated them with __stdcall)
+set_source_files_properties(Source/Network_20324.cpp PROPERTIES COMPILE_FLAGS "/Oi- /Gz")
+
+set_source_files_properties(Source/miss2_0x11C.cpp PROPERTIES COMPILE_FLAGS "/GX-")
+set_source_files_properties(Source/sharp_bose_0x54.cpp PROPERTIES COMPILE_FLAGS "/GX-")
+
+# NOICF is required because skip_ovly_5AAE20 and skip_psxt_5AAE30 have identical bodies and the linker will make them one and the same
+# however the real binary does have 2 copies. NOREF keeps functions that are not yet called so we can diff the content against the original.
+if (${MSVC_VERSION} GREATER 1200)
+    set (CMAKE_EXE_LINKER_FLAGS "/MAP:output.map /OPT:NOICF,NOREF /SAFESEH:NO" )
+else()
+    set (CMAKE_EXE_LINKER_FLAGS "/MAP:output.map /OPT:NOICF,NOREF" )
+endif()
+set (CMAKE_SHARED_LINKER_FLAGS "/OPT:NOICF,NOREF")
+
+set(CompilerFlags
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG
+        CMAKE_C_FLAGS_RELEASE
+)
+
+if (${MSVC_VERSION} EQUAL 1200)
+    foreach(CompilerFlag ${CompilerFlags})
+      string(REPLACE "/MD" "/ML /W3 /GX" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+
+    foreach(CompilerFlag ${CompilerFlags})
+      string(REPLACE "/Zi" "/Z7" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+
+    foreach(CompilerFlag ${CompilerFlags})
+      string(REPLACE "/Ob2" "" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+
+    foreach(CompilerFlag ${CompilerFlags})
+      string(REPLACE "/GR" "/EHsc" ${CompilerFlag} "${${CompilerFlag}}")
+    endforeach()
+endif()
+
+if (${MSVC_VERSION} GREATER 1200)
+   SET ( CMAKE_SHARED_LINKER_FLAGS /MANIFEST:NO )
+
+   if (NOT DEFINED ENV{CI})
+       add_custom_command(TARGET decomp_main POST_BUILD
+               COMMAND python build.py
+               WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+               COMMENT "Running build.py (VC6 build)")
+   endif()
+endif()
+
+message(STATUS "${MSVC_VERSION}=${${MSVC_VERSION}}")


### PR DESCRIPTION
The objective here is to be able to use an IDE with this project when MSVC is not installed in your main system.
Pretty much it guards the msvc specific bits with a compiler check and only enables them is MSVC is used.

Let me know if you agree with this changes, and if it breaks any of your workflows.