### PR TITLE
Fix crashes, debug Frontend classes

### DIFF
--- a/Source/ImGuiDebug.cpp
+++ b/Source/ImGuiDebug.cpp
@@ -14,12 +14,28 @@
 #include "collide.hpp"
 #include "debug.hpp"
 #include "gbh_graphics.hpp"
+#include "Frontend.hpp"
+#include "jolly_poitras_0x2BC0.hpp"
 #include <stdarg.h>
 
 extern EXPORT_VAR Ambulance_110* gAmbulance_110_6F70A8;
 extern EXPORT_VAR Collide_C* gCollide_C_6791FC;
 extern EXPORT_VAR Tango_54* gTango_54_67D4C0;
 extern EXPORT_VAR Orca_2FD4* gOrca_2FD4_6FDEF0;
+
+void wchar_to_char(wchar_t* wchar, char* out, u8 size)
+{
+    u16 i = 0;
+    for (; wchar[i]; i++)
+    {
+        out[(s8)i] = wchar[i];
+    }
+    // clear remaining slots
+    for (s8 j = i; j < size; j++)
+    {
+        out[j] = 0;
+    }
+}
 
 namespace ImGui
 {
@@ -67,6 +83,22 @@ bool Input_char_type(const char* label, char_type* v, int step, int step_fast, I
     return ret;
 }
 
+bool InputS16(const char* label, s16* v, int step, int step_fast, ImGuiInputTextFlags extra_flags = 0)
+{
+    int tmp = *v;
+    bool ret = ImGui::InputInt(label, &tmp, step, step_fast, extra_flags);
+    *v = static_cast<s16>(tmp);
+    return ret;
+}
+
+bool InputU16(const char* label, u16* v, int step, int step_fast, ImGuiInputTextFlags extra_flags = 0)
+{
+    int tmp = *v;
+    bool ret = ImGui::InputInt(label, &tmp, step, step_fast, extra_flags);
+    *v = static_cast<u16>(tmp);
+    return ret;
+}
+
 } // namespace ImGui
 
 EXPORT_VAR extern Shooey_CC* gShooey_CC_67A4B8;
@@ -98,24 +130,47 @@ void CC ImGuiDebugDraw()
         ImGui::TreePop();
     }
 
-    if (ImGui::TreeNode("gViewCamera_676978"))
+    if (ImGui::TreeNode("Camera"))
     {
-        if (gViewCamera_676978)
+        if (ImGui::TreeNode("gViewCamera_676978"))
         {
-            ImGui::Text("field_78_win_left %f", gViewCamera_676978->field_78_win_left.ToFloat());
-            ImGui::Text("field_7C_right %f", gViewCamera_676978->field_7C_win_right.ToFloat());
-            ImGui::Text("field_80_win_top %f", gViewCamera_676978->field_80_win_top.ToFloat());
-            ImGui::Text("field_84_win_bottom %f", gViewCamera_676978->field_84_win_bottom.ToFloat());
+            if (gViewCamera_676978)
+            {
+                ImGui::Text("field_78_win_left %f", gViewCamera_676978->field_78_win_left.ToFloat());
+                ImGui::Text("field_7C_right %f", gViewCamera_676978->field_7C_win_right.ToFloat());
+                ImGui::Text("field_80_win_top %f", gViewCamera_676978->field_80_win_top.ToFloat());
+                ImGui::Text("field_84_win_bottom %f", gViewCamera_676978->field_84_win_bottom.ToFloat());
+            }
+
+            if (ImGui::Button("Orca_2FD4::sub_5552B0"))
+            {
+                char xpos = gViewCamera_676978->field_78_win_left.ToInt() + 5;
+                char ypos = gViewCamera_676978->field_80_win_top.ToInt() + 5;
+                char zpos = 2;
+                if (gOrca_2FD4_6FDEF0->sub_5552B0(0, &xpos, &ypos, &zpos, 1))
+                {
+                }
+            }
+            ImGui::TreePop();
         }
 
-        if (ImGui::Button("Orca_2FD4::sub_5552B0"))
+        if (ImGui::TreeNode("Game Camera"))
         {
-            char xpos = gViewCamera_676978->field_78_win_left.ToInt() + 5;
-            char ypos = gViewCamera_676978->field_80_win_top.ToInt() + 5;
-            char zpos = 2;
-            if (gOrca_2FD4_6FDEF0->sub_5552B0(0, &xpos, &ypos, &zpos, 1))
+            if (gGame_0x40_67E008)
             {
+                Player* pPlayer = gGame_0x40_67E008->field_4_players[0];
+                if (pPlayer)
+                {
+                    DrawUnk_0xBC* game_camera = &pPlayer->field_90_game_camera;
+                    //DrawUnk_0xBC* view_camera = &pPlayer->field_14C_view_camera;
+                    //DrawUnk_0xBC* aux_camera = &pPlayer->field_208_aux_game_camera;
+                    if (game_camera)
+                    {
+                        ImGui::SliderInt("field_A4", &game_camera->field_A4.mValue, 0, 25000);
+                    }
+                }
             }
+            ImGui::TreePop();
         }
         ImGui::TreePop();
     }
@@ -642,6 +697,190 @@ void CC ImGuiDebugDraw()
             ImGui::TreePop();
         }
 
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("Frontend"))
+    {
+        if (ImGui::TreeNode("loving_borg_0xBCA"))
+        {
+            
+            if (gFrontend_67DC84)
+            {
+                static s32 loving_id = 0;
+                ImGui::SliderInt("Loving ID", &loving_id, 0, 16);
+
+                loving_borg_0xBCA* loving_borg = &gFrontend_67DC84->field_136[loving_id];
+                ImGui::Value("field_0", loving_borg->field_0);
+                ImGui::Value("field_2", loving_borg->field_2);
+                ImGui::Value("field_BC6_nifty_idx", loving_borg->field_BC6_nifty_idx);
+                ImGui::Value("field_BC8", loving_borg->field_BC8);
+
+                if (ImGui::TreeNode("nifty_maxwell_0x82"))
+                {
+                    static s32 nifty_id = 0;
+                    ImGui::SliderInt("Nifty Maxwell ID", &nifty_id, 0, 9);
+
+                    nifty_maxwell_0x82* nifty_maxwell = &loving_borg->field_4[nifty_id];
+
+                    ImGui::Value("field_0", nifty_maxwell->field_0);
+                    ImGui::Value("field_1", nifty_maxwell->field_1);
+
+                    ImGui::SliderS16("field_2", &nifty_maxwell->field_2, 0, 1000);
+                    ImGui::SliderS16("field_4", &nifty_maxwell->field_4, 0, 700);
+
+                    static char str_buf[50];
+                    wchar_to_char(nifty_maxwell->field_6_wstr_buf, str_buf, 50);
+                    ImGui::Text(str_buf);
+
+                    ImGui::Value("field_6A", nifty_maxwell->field_6A);
+                    ImGui::Value("field_6C", nifty_maxwell->field_6C);
+                    ImGui::Value("field_6E_count", nifty_maxwell->field_6E_count);
+                    ImGui::Value("field_70", nifty_maxwell->field_70);
+
+                    ImGui::Text(nifty_maxwell->field_72);
+
+                    ImGui::Value("field_7E", nifty_maxwell->field_7E);
+                    ImGui::Value("field_80", nifty_maxwell->field_80);
+
+                    ImGui::TreePop();
+                }
+
+                if (ImGui::TreeNode("competent_noyce_0x6E"))
+                {
+                    static s32 noyce_id = 0;
+                    ImGui::SliderInt("Competent Noyce ID", &noyce_id, 0, 14);
+
+                    competent_noyce_0x6E* competent_noyce = &loving_borg->field_518[noyce_id];
+
+                    ImGui::Value("field_0", competent_noyce->field_0);
+                    ImGui::Value("field_1", competent_noyce->field_1);
+
+                    ImGui::SliderS16("field_2_xpos", &competent_noyce->field_2_xpos, 0, 1000);
+                    ImGui::SliderS16("field_4_ypos", &competent_noyce->field_4_ypos, 0, 700);
+
+                    static char str_buf_2[50];
+                    wchar_to_char(competent_noyce->field_6_wstr_buf, str_buf_2, 50);
+                    ImGui::Text(str_buf_2);
+
+                    ImGui::InputU16("field_6A", &competent_noyce->field_6A, 1, 1);
+                    ImGui::InputU16("field_6C", &competent_noyce->field_6C, 1, 1);
+
+                    ImGui::TreePop();
+                }
+
+                if (ImGui::TreeNode("kind_beaver_6"))
+                {
+                    static s32 k_beaver_id = 0;
+                    ImGui::SliderInt("Kind Beaver ID", &k_beaver_id, 0, 9);
+
+                    kind_beaver_6* kind_beaver = &loving_borg->field_B8A[k_beaver_id];
+
+                    ImGui::SliderS16("field_0", &kind_beaver->field_0, 0, 1000);
+                    ImGui::SliderS16("field_2", &kind_beaver->field_2, 0, 700);
+
+                    ImGui::Value("field_4", kind_beaver->field_4);
+                    ImGui::Value("field_5", kind_beaver->field_5);
+
+                    ImGui::TreePop();
+                }
+                
+
+            }
+            ImGui::TreePop();
+        }
+        
+        ImGui::TreePop();
+    }
+    
+    if (ImGui::TreeNode("gJolly_poitras_0x2BC0_6FEAC0"))
+    {
+        if (gJolly_poitras_0x2BC0_6FEAC0)
+        {
+            if (ImGui::TreeNode("struc_221"))
+            {
+                static s32 struc_221_id = 0;
+                ImGui::SliderInt("struc_221 ID", &struc_221_id, 0, 2);
+                struc_221* struc = &gJolly_poitras_0x2BC0_6FEAC0->field_1800[struc_221_id];
+
+                static s32 byte_id = 0;
+                ImGui::SliderInt("Byte ID", &byte_id, 0, 39);
+                ImGui::Value("field_0 at id", struc->field_0[byte_id]);
+                ImGui::TreePop();
+            }
+
+            if (ImGui::TreeNode("agitated_keldysh_0xF0"))
+            {
+                static s32 agitated_type = 0;
+
+                const char* agitated_fields[] = {"field_1890", "field_23D0",
+                                                "field_24C0", "field_25B0"};
+                ImGui::Combo("agitated_field", &agitated_type, agitated_fields, 4);
+
+                static s32 id_1 = 0;
+                static s32 id_2 = 0;
+                ImGui::SliderInt("field_1890 ID 1", &id_1, 0, 2);
+                ImGui::SliderInt("field_1890 ID 2", &id_2, 0, 3);
+                
+                agitated_keldysh_0xF0* agitated_keldysh;
+
+                switch(agitated_type)
+                {
+                    case 0:
+                        agitated_keldysh = &gJolly_poitras_0x2BC0_6FEAC0->field_1890[id_1][id_2];
+                        break;
+                    case 1:
+                        agitated_keldysh = &gJolly_poitras_0x2BC0_6FEAC0->field_23D0;
+                        break;
+                    case 2:
+                        agitated_keldysh = &gJolly_poitras_0x2BC0_6FEAC0->field_24C0;
+                        break;
+                    case 3:
+                        agitated_keldysh = &gJolly_poitras_0x2BC0_6FEAC0->field_25B0;
+                        break;
+                    default:
+                        break;
+                }
+
+                static s32 string_id = 0;
+                ImGui::SliderInt("string_id", &string_id, 0, 9);
+                small_string* s_string = &agitated_keldysh->field_0[string_id];
+
+                static char str_buf_3[10];
+                wchar_to_char(s_string->field_0_str, str_buf_3, 10);
+                ImGui::Text(str_buf_3);
+                ImGui::Value("field_14_score", s_string->field_14_score);
+
+                ImGui::TreePop();
+            }
+
+            if (ImGui::TreeNode("dreamy_clarke_0xA4"))
+            {
+                static s32 dreamy_id = 0;
+                ImGui::SliderInt("dreamy_id", &dreamy_id, 0, 7);
+                dreamy_clarke_0xA4* dreamy = &gJolly_poitras_0x2BC0_6FEAC0->field_26A0[dreamy_id];
+
+                static char str_buf_4[9];
+                wchar_to_char(dreamy->field_90_strPlayerName, str_buf_4, 9);
+                ImGui::Text(str_buf_4);
+                ImGui::Value("field_A2", dreamy->field_A2);
+
+                static s32 gifted_joliot_id_1 = 0;
+                static s32 gifted_joliot_id_2 = 0;
+                ImGui::SliderInt("gifted_joliot ID 1", &gifted_joliot_id_1, 0, 2);
+                ImGui::SliderInt("gifted_joliot ID 2", &gifted_joliot_id_2, 0, 3);
+                gifted_joliot* g_joliot = &dreamy->field_0[gifted_joliot_id_1][gifted_joliot_id_2];
+
+                ImGui::Value("Joliot field_0", g_joliot->field_0);
+                ImGui::Value("Joliot field_1", g_joliot->field_1);
+                ImGui::Value("Joliot field_2", g_joliot->field_2);
+                ImGui::Value("Joliot field_3", g_joliot->field_3);
+                ImGui::Value("Joliot field_4", g_joliot->field_4);
+                ImGui::Value("Joliot field_8", g_joliot->field_8);
+
+                ImGui::TreePop();
+            }
+        }
         ImGui::TreePop();
     }
 

--- a/Source/Object_5C.cpp
+++ b/Source/Object_5C.cpp
@@ -57,10 +57,16 @@ s32 Object_2C::sub_5222D0()
     return 0;
 }
 
-STUB_FUNC(0x522340)
-Object_29178* Object_2C::sub_522340()
+MATCH_FUNC(0x522340)
+void Object_2C::sub_522340()
 {
-    return 0;
+    if (field_20 == 2)
+    {
+        Object_29178* pRoot = gObject_29178_6F8F80;
+        field_0 = pRoot->field_4;
+        pRoot->field_4 = this;
+        field_20 = 1;
+    }
 }
 
 STUB_FUNC(0x522360)

--- a/Source/Object_5C.hpp
+++ b/Source/Object_5C.hpp
@@ -22,7 +22,7 @@ class Object_2C
     EXPORT bool sub_522250(Sprite* a2);
     EXPORT s32 sub_5222B0();
     EXPORT s32 sub_5222D0();
-    EXPORT Object_29178* sub_522340();
+    EXPORT void sub_522340();
     EXPORT void sub_522360();
     EXPORT char_type sub_5223C0(Sprite* a2);
     EXPORT bool sub_522430(Sprite* a2);

--- a/Source/gbh_graphics.cpp
+++ b/Source/gbh_graphics.cpp
@@ -100,7 +100,7 @@ EXPORT_VAR T_MakeScreenTable pMakeScreenTable;
 GLOBAL(pMakeScreenTable, 0x626CD0);
 
 EXPORT_VAR T_ConvertColourBank pConvertColourBank;
-GLOBAL(pConvertColourBank, 0x0);
+GLOBAL(pConvertColourBank, 0x626CD4);
 
 EXPORT_VAR T_SetShadeTableA pSetShadeTableA;
 GLOBAL(pSetShadeTableA, 0x626CD8);

--- a/Source/winmain.cpp
+++ b/Source/winmain.cpp
@@ -1632,164 +1632,165 @@ s32 __stdcall WinMain_5E53F0(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR
         gRegistry_6FF968.Clear_Or_Delete_Sound_Setting_586BF0("do_3d_sound", gRoot_sound_66B038.Get3DSound_40F180());
     }
 
-    s32 bQuit = 0;
+    u8 bQuit = 0;    //  %bl
 
-LABEL_23:
     while (1)
     {
-
-        if (!bDoFrontEnd_626B68)
+        if (bDoFrontEnd_626B68)
         {
-            break;
+            Frontend::create_4ACFA0();
+            gFrontend_67DC84->sub_4B3170(state);
         }
-
-        Frontend::create_4ACFA0();
-        gFrontend_67DC84->sub_4B3170(state);
-
-    LABEL_27:
+        else
+        {
+            sub_4DA4D0();
+            if (bStartNetworkGame_7081F0 && !gNetPlay_7071E8.sub_5213E0())
+            {
+                CoUninitialize();
+                return 0;
+            }
+        }
+        
         UpdateWinXY_5D8E70();
         sub_5D9690();
 
         while (1)
         {
-            do
+            MSG msg;
+            if (PeekMessageA(&msg, 0, 0, 0, 1u))
             {
-                while (1)
+                if (msg.message == 18) // WM_QUIT
                 {
-                    // Message processing
-                    do
-                    {
-                        MSG msg;
-                        while (PeekMessageA(&msg, 0, 0, 0, 1u))
-                        {
-                            // label here
-                            if (msg.message == 18) // WM_QUIT
-                            {
-                                Input::DInputRelease_498710();
-                                return msg.wParam;
-                            }
-                            TranslateMessage(&msg);
-                            DispatchMessageA(&msg);
-                        }
-                    } while ((BYTE)bQuit || byte_70827C == 2 || byte_706C5D);
-
-                    if (!bDoFrontEnd_626B68)
-                    {
-                        break;
-                    }
-
-                    // or switch ?
-                    s32 t = gFrontend_67DC84->sub_4AEDB0();
-                    if (t == 1)
-                    {
-                        bQuit = 1;
-                        Frontend::destroy_4AD070();
-                        DestroyWindow(gHwnd_707F04);
-                    }
-                    else if (t == 3)
-                    {
-                        Frontend::destroy_4AD070();
-                        bDoFrontEnd_626B68 = 0;
-                        goto LABEL_23;
-                    }
-                    else if (t == 4)
-                    {
-                        Frontend::destroy_4AD070();
-                        bDoFrontEnd_626B68 = 0;
-                        byte_6F5B71 = 1;
-                        goto LABEL_23;
-                    }
+                    Input::DInputRelease_498710();
+                    return msg.wParam;
                 }
-                bQuit = sub_4DA850();
-            } while (!(BYTE)bQuit);
-
-            if (!bSkip_frontend_67D53B)
-            {
-                break;
-            }
-
-            DestroyWindow(gHwnd_707F04);
-        } // loop end
-
-        if (bStartNetworkGame_7081F0)
-        {
-            if (gGame_0x40_67E008->field_2C_main_state == 1)
-            {
-                DestroyWindow(gHwnd_707F04);
+                TranslateMessage(&msg);
+                DispatchMessageA(&msg);
             }
             else
             {
-                state = 7;
-                CleanUpInputAndOthers_4DA700();
-                bDoFrontEnd_626B68 = 1;
+                if (!bQuit && byte_70827C != 2 && !byte_706C5D) //  line 3e4
+                {
+                    if (bDoFrontEnd_626B68)
+                    {
+                        s32 t = gFrontend_67DC84->sub_4AEDB0();
+
+                        if (t == 1)
+                        {
+                            bQuit = 1;
+                            Frontend::destroy_4AD070();
+                            DestroyWindow(gHwnd_707F04);
+                            continue; // go to PeekMessageA
+                        }
+                        else if (t == 3)
+                        {
+                            Frontend::destroy_4AD070();
+                            bDoFrontEnd_626B68 = 0;
+                            break; // go to the beginning
+                        }
+                        else if (t == 4)
+                        {
+                            Frontend::destroy_4AD070();
+                            bDoFrontEnd_626B68 = 0;
+                            byte_6F5B71 = 1;
+                            break; // go to the beginning
+                        }
+                        else
+                        {
+                            continue; // go to PeekMessageA
+                        }
+                    
+                    }
+                    bQuit = sub_4DA850();
+
+                    if (bQuit)
+                    {
+                        if (bSkip_frontend_67D53B)
+                        {
+                            DestroyWindow(gHwnd_707F04);
+                        }
+                        else
+                        {
+                            if (bStartNetworkGame_7081F0)
+                            {
+                                switch (gGame_0x40_67E008->field_2C_main_state)
+                                {
+                                    case 1:
+                                        DestroyWindow(gHwnd_707F04);
+                                        break;
+                                
+                                    default:
+                                        state = 7;
+                                        CleanUpInputAndOthers_4DA700();
+                                        bDoFrontEnd_626B68 = 1;
+                                        break;
+                                }
+                                break;    // go to the beginning
+                            }
+                            else
+                            {
+                                switch (gGame_0x40_67E008->field_2C_main_state)
+                                {
+                                    case 1:
+                                        DestroyWindow(gHwnd_707F04);
+                                        break;
+                    
+                                    case 2:
+                                        gLucid_hamilton_67E8E0.sub_4C5A10(gGame_0x40_67E008->field_38_orf1);
+                                        gJolly_poitras_0x2BC0_6FEAC0->sub_56BB10(gGame_0x40_67E008->field_38_orf1);
+                                        gJolly_poitras_0x2BC0_6FEAC0->sub_56C010();
+                                        
+                                        state = gLucid_hamilton_67E8E0.sub_4C59A0() != 0 ? 6 : 11; // 11? prob 1
+                                        CleanUpInputAndOthers_4DA700();
+                                        bDoFrontEnd_626B68 = 1;
+                                        break;
+                    
+                                    case 3:
+                                        gLucid_hamilton_67E8E0.sub_4C5A10(gGame_0x40_67E008->field_38_orf1);
+                                        gJolly_poitras_0x2BC0_6FEAC0->sub_56BB10(gGame_0x40_67E008->field_38_orf1);
+                                        gJolly_poitras_0x2BC0_6FEAC0->sub_56C010();
+                                        state = gLucid_hamilton_67E8E0.sub_4C59A0() != 0 ? 6 : 2;
+                                        CleanUpInputAndOthers_4DA700();
+                                        bDoFrontEnd_626B68 = 1;
+                                        break;
+                    
+                                    case 4:
+                                        gLucid_hamilton_67E8E0.sub_4C5A10(gGame_0x40_67E008->field_38_orf1);
+                                        gJolly_poitras_0x2BC0_6FEAC0->sub_56BB10(gGame_0x40_67E008->field_38_orf1);
+                                        gJolly_poitras_0x2BC0_6FEAC0->sub_56C010();
+                                        state = gLucid_hamilton_67E8E0.sub_4C59A0() != 0 ? 6 : 3;
+                                        CleanUpInputAndOthers_4DA700();
+                                        bDoFrontEnd_626B68 = 1;
+                                        break;
+                    
+                                    case 5:
+                                        state = 7;
+                                        CleanUpInputAndOthers_4DA700();
+                                        bDoFrontEnd_626B68 = 1;
+                                        break;
+                    
+                                    case 6:
+                                        state = 0;
+                                        CleanUpInputAndOthers_4DA700();
+                                        bDoFrontEnd_626B68 = 1;
+                                        break;
+                    
+                                    default:
+                                        continue; // go to PeekMessageA
+                                }
+                                break; // go to the beginning
+                            }
+                            //  nothing here
+                        }
+                        //  nothing here
+                    }
+                    // nothing here
+                }
             }
         }
-        else
-        {
-            switch (gGame_0x40_67E008->field_2C_main_state)
-            {
-                case 1:
-                    DestroyWindow(gHwnd_707F04);
-                    break;
 
-                case 2:
-                    gLucid_hamilton_67E8E0.sub_4C5A10(gGame_0x40_67E008->field_38_orf1);
-                    gJolly_poitras_0x2BC0_6FEAC0->sub_56BB10(gGame_0x40_67E008->field_38_orf1);
-                    gJolly_poitras_0x2BC0_6FEAC0->sub_56C010();
-                    /* todo
-                v15 = -(gLucid_hamilton_67E8E0.sub_4C59A0() != 0);
-                v15 = v15 & 0xFB; //lobyte
-                state = v15 + 11; //loword
-                */
-                    state = gLucid_hamilton_67E8E0.sub_4C59A0() != 0 ? 6 : 1; // 11? prob 1
-                    CleanUpInputAndOthers_4DA700();
-                    bDoFrontEnd_626B68 = 1;
-                    break;
-
-                case 3:
-                    gLucid_hamilton_67E8E0.sub_4C5A10(gGame_0x40_67E008->field_38_orf1);
-                    gJolly_poitras_0x2BC0_6FEAC0->sub_56BB10(gGame_0x40_67E008->field_38_orf1);
-                    gJolly_poitras_0x2BC0_6FEAC0->sub_56C010();
-                    state = gLucid_hamilton_67E8E0.sub_4C59A0() != 0 ? 6 : 2;
-                    CleanUpInputAndOthers_4DA700();
-                    bDoFrontEnd_626B68 = 1;
-                    break;
-
-                case 4:
-                    gLucid_hamilton_67E8E0.sub_4C5A10(gGame_0x40_67E008->field_38_orf1);
-                    gJolly_poitras_0x2BC0_6FEAC0->sub_56BB10(gGame_0x40_67E008->field_38_orf1);
-                    gJolly_poitras_0x2BC0_6FEAC0->sub_56C010();
-                    state = gLucid_hamilton_67E8E0.sub_4C59A0() != 0 ? 6 : 3;
-                    CleanUpInputAndOthers_4DA700();
-                    bDoFrontEnd_626B68 = 1;
-                    break;
-
-                case 5:
-                    state = 7;
-                    CleanUpInputAndOthers_4DA700();
-                    bDoFrontEnd_626B68 = 1;
-                    break;
-
-                case 6:
-                    state = 0;
-                    CleanUpInputAndOthers_4DA700();
-                    bDoFrontEnd_626B68 = 1;
-                    break;
-
-                default:
-                    continue;
-            }
-        }
+        //  nothing here
     }
-
-    sub_4DA4D0();
-
-    if (!bStartNetworkGame_7081F0 || gNetPlay_7071E8.sub_5213E0())
-    {
-        goto LABEL_27;
-    }
-
-    CoUninitialize();
     return 0;
 }
 


### PR DESCRIPTION
match Object_2C::sub_522340
Improve WinMain_5E53F0: all goto's removed, and it's more closer to a match
Fix standalone/patched crashes due to null pointer in gbh_graphics.

New debug stuff:
From Frontend:
- loving_borg_0xBCA
- nifty_maxwell_0x82
- competent_noyce_0x6E
- kind_beaver_6

From Jolly_poitras:
- struc_221
- agitated_keldysh_0xF0
- dreamy_clarke_0xA4
- gifted_joliot