### PR TITLE
Reestructure DrawUnk_0xBC and some matches

### DIFF
--- a/Source/Ambulance_110.cpp
+++ b/Source/Ambulance_110.cpp
@@ -1,6 +1,13 @@
 #include "Ambulance_110.hpp"
 #include "Ped.hpp"
+#include "PedGroup.hpp"
+#include "Kfc_1E0.hpp"
+#include "Car_BC.hpp"
+#include "Globals.hpp"
 #include <stdio.h>
+
+EXPORT_VAR s32 dword_6F6DD4;
+GLOBAL(dword_6F6DD4, 0x6F6DD4);
 
 MATCH_FUNC(0x4beab0)
 Ambulance_20::Ambulance_20()
@@ -38,11 +45,72 @@ void Ambulance_20::sub_4FA800(Ped* pPed)
     field_14_count++;
 }
 
-STUB_FUNC(0x4fa820)
-char_type Ambulance_20::sub_4FA820()
+MATCH_FUNC(0x4fa820)
+bool Ambulance_20::sub_4FA820()
 {
-    NOT_IMPLEMENTED;
-    return 0;
+    PedGroup* pGroup = PedGroup::sub_4CB0D0();
+    if (!pGroup)
+    {
+        return false;
+    }
+
+    if (gChar_C_6787BC->field_5 >= 30u)
+    {
+        return false;
+    }
+
+    Ped* pPed1 = gChar_C_6787BC->sub_470F30();
+    if (!pPed1)
+    {
+        return false;
+    }
+    pPed1->field_238 = 4;
+    pPed1->field_240_occupation = ped_ocupation_enum::unknown_13;
+    pPed1->field_230 = 2;
+    pPed1->sub_45C730(field_4->field_0);
+    pPed1->SetObjective(objectives_enum::goto_area_in_car_14, 0);
+    pPed1->field_1DC_objective_target_x = (unsigned __int8)this->field_0 << 14;
+    pPed1->field_1E0_objective_target_y = (unsigned __int8)this->field_1 << 14;
+    pPed1->field_1E4_objective_target_z = (unsigned __int8)this->field_2 << 14;
+    pPed1->field_28C_threat_reaction = threat_reaction_enum::react_as_emergency_1;
+    pPed1->field_288_threat_search = threat_search_enum::no_threats_0;
+    pPed1->field_244_remap = 16;
+    pPed1->field_26C_graphic_type = 0;
+    pPed1->field_1F8 = dword_6F6DD4;
+
+    Ped* pPed2 = gChar_C_6787BC->sub_470F30();
+    if (!pPed2)
+    {
+        return false;
+    }
+
+    pPed2->sub_45C7F0(field_4->field_0);
+    pPed2->field_238 = 4;
+    pPed2->field_240_occupation = ped_ocupation_enum::unknown_13;
+    pPed2->field_230 = 2;
+    pPed2->SetObjective(objectives_enum::no_obj_0, 9999);
+    pPed2->field_244_remap = 16;
+    pPed2->field_26C_graphic_type = 0;
+    pPed2->field_28C_threat_reaction = threat_reaction_enum::react_as_emergency_1;
+    pPed2->field_288_threat_search = threat_search_enum::no_threats_0;
+    pGroup->add_ped_leader_4C9B10(pPed1);
+    pGroup->field_36_count = 1;
+    pGroup->field_34_count = 1;
+    pGroup->add_ped_to_list_4C9B30(pPed2, 0);
+    pGroup->field_0 = 0;
+    field_4->field_4 = pPed1;
+    field_4->field_28 = 6;
+
+    Car_BC* pCar = field_4->field_0;
+
+    pCar->field_7C_uni_num = 4;
+    pCar->field_76 = 0;
+
+    field_4->field_0->sub_43BCA0();
+    field_4->field_0->sub_440590();
+    field_4->field_0->sub_43AF40();
+    field_4->field_8 = pGroup;
+    return true;
 }
 
 STUB_FUNC(0x4fa9d0)

--- a/Source/Ambulance_110.hpp
+++ b/Source/Ambulance_110.hpp
@@ -20,7 +20,7 @@ class Ambulance_20
     EXPORT ~Ambulance_20();
     EXPORT void sub_4FA7D0();
     EXPORT void sub_4FA800(Ped* pPed);
-    EXPORT char_type sub_4FA820();
+    EXPORT bool sub_4FA820();
     EXPORT char_type sub_4FA9D0();
     EXPORT u32* sub_4FAAC0();
     EXPORT void sub_4FB330();

--- a/Source/Car_BC.cpp
+++ b/Source/Car_BC.cpp
@@ -124,6 +124,18 @@ GLOBAL(DAT_006FF778, 0x6ff778);
 EXPORT_VAR Fix16 dword_7035C4;
 GLOBAL(dword_7035C4, 0x7035C4);
 
+EXPORT_VAR Fix16 dword_6F7690;
+GLOBAL(dword_6F7690, 0x6F7690);
+
+EXPORT_VAR Fix16 dword_6F77D4;
+GLOBAL(dword_6F77D4, 0x6F77D4);
+
+EXPORT_VAR Ang16 word_6F804C;
+GLOBAL(word_6F804C, 0x6F804C);
+
+EXPORT_VAR Ang16 word_6F771E;
+GLOBAL(word_6F771E, 0x6F771E);
+
 MATCH_FUNC(0x5639c0)
 void sub_5639C0()
 {
@@ -1019,7 +1031,7 @@ void Sprite::sub_5A3030()
 }
 
 STUB_FUNC(0x5a3100)
-void Sprite::sub_5A3100(Sprite* a2, s32 a3, Sprite* a4, Ang16 a5)
+void Sprite::sub_5A3100(Sprite* a2, Fix16 a3, Fix16 a4, Ang16 a5)
 {
     NOT_IMPLEMENTED;
 }
@@ -1165,7 +1177,7 @@ Car_BC* Car_6C::sub_446230(Fix16 xpos, Fix16 ypos, Fix16 zpos, Ang16 rotation, s
 }
 
 STUB_FUNC(0x446530)
-Car_A4_10* Car_6C::sub_446530(s32 a2, s32 a3, Car_BC* a4, s32 a5, s32 a6)
+Car_A4_10* Car_6C::sub_446530(Fix16 xpos, Fix16 ypos, Ang16 rotation, s32 car_idx, s32 trailer_idx)
 {
     NOT_IMPLEMENTED;
     return 0;

--- a/Source/Car_BC.cpp
+++ b/Source/Car_BC.cpp
@@ -3374,14 +3374,14 @@ char Car_14::sub_582360(int param_1, Fix16 param_2, Fix16 param_3)
         case 2:
             if (field_8 == 0)
             {
-                if (param_2 < (field_0->field_7C_win_right - DAT_006FF778))
+                if (param_2 < (field_0->field_78_boundaries_non_neg.field_4_right - DAT_006FF778))
                 {
                     return 1;
                 }
             }
             else
             {
-                if (param_2 > (field_0->field_78_win_left + DAT_006FF778))
+                if (param_2 > (field_0->field_78_boundaries_non_neg.field_0_left + DAT_006FF778))
                 {
                     return 1;
                 }
@@ -3391,14 +3391,14 @@ char Car_14::sub_582360(int param_1, Fix16 param_2, Fix16 param_3)
         case 4:
             if (field_8 == 0)
             {
-                if (param_3 < (field_0->field_84_win_bottom - DAT_006FF778))
+                if (param_3 < (field_0->field_78_boundaries_non_neg.field_C_bottom - DAT_006FF778))
                 {
                     return 1;
                 }
             }
             else
             {
-                if (param_3 > (field_0->field_80_win_top + DAT_006FF778))
+                if (param_3 > (field_0->field_78_boundaries_non_neg.field_8_top + DAT_006FF778))
                 {
                     return 1;
                 }

--- a/Source/Car_BC.hpp
+++ b/Source/Car_BC.hpp
@@ -204,7 +204,7 @@ class Sprite
     EXPORT void sub_5A2A30();
     EXPORT void Init_5A2CF0();
     EXPORT void sub_5A3030();
-    EXPORT void sub_5A3100(Sprite* a2, s32 a3, Sprite* a4, Ang16 a5);
+    EXPORT void sub_5A3100(Sprite* a2, Fix16 a3, Fix16 a4, Ang16 a5);
 
     EXPORT ~Sprite(); // 0x5a3540
 
@@ -327,6 +327,11 @@ class Car_2
     u16 field_0;
 };
 
+EXPORT_VAR extern Fix16 dword_6F7690;
+EXPORT_VAR extern Fix16 dword_6F77D4;
+EXPORT_VAR extern Ang16 word_6F804C;
+EXPORT_VAR extern Ang16 word_6F771E;
+
 class Car_6C
 {
   public:
@@ -337,7 +342,7 @@ class Car_6C
     EXPORT Car_BC* sub_444FA0(Fix16 x, Fix16 y, Fix16 z, Ped* pPed);
     EXPORT Car_BC* sub_4458B0(s32 arg0, s32 a3, s32 a4, s32 a2);
     EXPORT Car_BC* sub_446230(Fix16 xpos, Fix16 ypos, Fix16 zpos, Ang16 rotation, s32 car_info_idx, Fix16 maybe_w_scale);
-    EXPORT Car_A4_10* sub_446530(s32 a2, s32 a3, Car_BC* a4, s32 a5, s32 a6);
+    EXPORT Car_A4_10* sub_446530(Fix16 xpos, Fix16 ypos, Ang16 rotation, s32 car_idx, s32 trailer_idx);
     EXPORT void sub_446730(Car_BC *pCar);
 
     EXPORT s32 sub_4466C0(s32 a2);
@@ -347,6 +352,24 @@ class Car_6C
     EXPORT u32 sub_446930(s32 a2);
     EXPORT Car_6C();
     EXPORT ~Car_6C();
+    
+    // 9.6f inlined
+    inline Car_BC* sub_426E10(Fix16 xpos, Fix16 ypos, Fix16 zpos, Ang16 rotation, s32 car_info_idx)
+    {
+        return sub_446230(xpos, ypos, zpos, rotation, car_info_idx, dword_6F77C4);
+    }
+
+    // 9.6f inlined
+    inline Car_BC* sub_4764A0(Fix16 xpos, Fix16 ypos, Fix16 zpos, Ang16 rotation, s32 car_info_idx)
+    {
+        return sub_446230(xpos, ypos, zpos, rotation, car_info_idx, dword_6F7690);
+    }
+
+    // unknown inlined function
+    inline Car_BC* sub_446230_shortened(s32 car_info_idx)
+    {
+        return sub_446230(dword_6F77D4, dword_6F77D4, dword_6F77C0, word_6F804C, car_info_idx, dword_6F77C4);
+    }
 
     Car_2 field_0;
     s16 field_2;

--- a/Source/DrawUnk_0xBC.cpp
+++ b/Source/DrawUnk_0xBC.cpp
@@ -134,47 +134,39 @@ s32 DrawUnk_0xBC::sub_435B90()
     return 0;
 }
 
-STUB_FUNC(0x435D20)
+MATCH_FUNC(0x435D20)
 void DrawUnk_0xBC::sub_435D20(char_type a2, char_type a3, char_type a4, char_type a5, char_type a6, char_type a7)
 {
-    NOT_IMPLEMENTED;
     sub_41E410_reversed();
-    /*
-    field_10 = field_0;
-    field_14 = field_4_unk;
-    field_18 = field_8;
-    field_1C = field_C;
-    */
     if (a2)
     {
-        field_10_cam_pos_tgt2.field_4_y -= dword_67671C;//field_14 -= dword_67671C;
+        field_10_cam_pos_tgt2.field_4_y -= dword_67671C;
     }
 
     if (a3)
     {
-        field_10_cam_pos_tgt2.field_4_y += dword_67671C;//field_14 += dword_67671C;
+        field_10_cam_pos_tgt2.field_4_y += dword_67671C;
     }
 
     if (a4)
     {
-        field_10_cam_pos_tgt2.field_0_x -= dword_67671C;//field_10 -= dword_67671C;
+        field_10_cam_pos_tgt2.field_0_x -= dword_67671C;
     }
 
     if (a5)
     {
-        field_10_cam_pos_tgt2.field_0_x += dword_67671C;//field_10 += dword_67671C;
+        field_10_cam_pos_tgt2.field_0_x += dword_67671C;
     }
 
     if (a6)
     {
-        field_10_cam_pos_tgt2.field_8_z += dword_67681C;//field_18 += dword_67681C;
+        field_10_cam_pos_tgt2.field_8_z += dword_67681C;
     }
 
     if (a7)
     {
-        field_10_cam_pos_tgt2.field_8_z -= dword_67681C;//field_18 -= dword_67681C;
+        field_10_cam_pos_tgt2.field_8_z -= dword_67681C;
     }
-
     sub_435840();
 }
 

--- a/Source/DrawUnk_0xBC.cpp
+++ b/Source/DrawUnk_0xBC.cpp
@@ -41,10 +41,10 @@ char_type DrawUnk_0xBC::sub_435630(s16* a2, s32 a3)
 MATCH_FUNC(0x4357B0)
 void DrawUnk_0xBC::sub_4357B0()
 {
-    field_88 = field_98_x;
-    field_8C = field_9C_y;
-    field_90 = field_A0_z;
-    field_94 = field_A4;
+    field_88_cam_pos1.field_0_x = field_98_cam_pos2.field_0_x;
+    field_88_cam_pos1.field_4_y = field_98_cam_pos2.field_4_y;
+    field_88_cam_pos1.field_8_z = field_98_cam_pos2.field_8_z;
+    field_88_cam_pos1.field_C_zoom = field_98_cam_pos2.field_C_zoom;
 }
 
 EXPORT_VAR Fix16 dword_676894;
@@ -97,10 +97,10 @@ void DrawUnk_0xBC::sub_435840()
 MATCH_FUNC(0x435860)
 void DrawUnk_0xBC::sub_435860(DrawUnk_0xBC* a2)
 {
-    field_10_cam_pos_tgt2.field_0_x += a2->field_98_x - a2->field_88;
-    field_10_cam_pos_tgt2.field_4_y += a2->field_9C_y - a2->field_8C;
-    field_10_cam_pos_tgt2.field_8_z += a2->field_A0_z - a2->field_90;
-    field_10_cam_pos_tgt2.field_C_zoom += a2->field_A4 - a2->field_94;
+    field_10_cam_pos_tgt2.field_0_x += a2->field_98_cam_pos2.field_0_x - a2->field_88_cam_pos1.field_0_x;
+    field_10_cam_pos_tgt2.field_4_y += a2->field_98_cam_pos2.field_4_y - a2->field_88_cam_pos1.field_4_y;
+    field_10_cam_pos_tgt2.field_8_z += a2->field_98_cam_pos2.field_8_z - a2->field_88_cam_pos1.field_8_z;
+    field_10_cam_pos_tgt2.field_C_zoom += a2->field_98_cam_pos2.field_C_zoom - a2->field_88_cam_pos1.field_C_zoom;
     sub_435840();
 }
 
@@ -176,10 +176,10 @@ void DrawUnk_0xBC::sub_435D20(char_type a2, char_type a3, char_type a4, char_typ
 MATCH_FUNC(0x435DD0)
 void DrawUnk_0xBC::sub_435DD0()
 {
-    field_98_x = field_0_cam_pos_tgt1.field_0_x;//field_0;
-    field_9C_y = field_0_cam_pos_tgt1.field_4_y;//field_4_unk;
-    field_A0_z = field_0_cam_pos_tgt1.field_8_z;
-    field_A4 = field_0_cam_pos_tgt1.field_C_zoom;//field_C;
+    field_98_cam_pos2.field_0_x = field_0_cam_pos_tgt1.field_0_x;
+    field_98_cam_pos2.field_4_y = field_0_cam_pos_tgt1.field_4_y;
+    field_98_cam_pos2.field_8_z = field_0_cam_pos_tgt1.field_8_z;
+    field_98_cam_pos2.field_C_zoom = field_0_cam_pos_tgt1.field_C_zoom;
 
     field_AC_cam_velocity.field_0_x = dword_676818;
     field_AC_cam_velocity.field_4_y = dword_676818;
@@ -293,7 +293,7 @@ DrawUnk_0xBC::DrawUnk_0xBC()
     field_68 = 0;
     field_6C = 0;
     sub_435830();
-    field_A4 = dword_6766D4;
+    field_98_cam_pos2.field_C_zoom = dword_6766D4;
     sub_4397D0(-1, -1, -1, dword_6766D4);
     ctor_inline(640, 480);
     field_44 = 0;
@@ -318,5 +318,8 @@ void DrawUnk_0xBC::sub_4397D0(Fix16 a2, Fix16 a3, Fix16 a4, Fix16 a5)
 MATCH_FUNC(0x58CF10)
 bool DrawUnk_0xBC::sub_58CF10(Fix16 a2, Fix16 a3)
 {
-    return a2 >= field_78_win_left && a2 <= field_7C_win_right && a3 >= field_80_win_top && a3 <= field_84_win_bottom;
+    return a2 >= field_78_boundaries_non_neg.field_0_left 
+        && a2 <= field_78_boundaries_non_neg.field_4_right 
+        && a3 >= field_78_boundaries_non_neg.field_8_top 
+        && a3 <= field_78_boundaries_non_neg.field_C_bottom;
 }

--- a/Source/DrawUnk_0xBC.cpp
+++ b/Source/DrawUnk_0xBC.cpp
@@ -21,6 +21,9 @@ GLOBAL(dword_676818, 0x676818);
 EXPORT_VAR Fix16 dword_67681C;
 GLOBAL(dword_67681C, 0x67681C);
 
+EXPORT_VAR Fix16 dword_6766D4;
+GLOBAL(dword_6766D4, 0x6766D4);
+
 STUB_FUNC(0x4355D0)
 char_type DrawUnk_0xBC::sub_4355D0(Sprite* a2)
 {
@@ -178,10 +181,10 @@ void DrawUnk_0xBC::sub_435DD0()
     field_A0_z = field_0_cam_pos_tgt1.field_8_z;
     field_A4 = field_0_cam_pos_tgt1.field_C_zoom;//field_C;
 
-    field_AC = dword_676818;
-    field_B0 = dword_676818;
-    field_B4 = dword_676818;
-    field_B8 = dword_676818;
+    field_AC_cam_velocity.field_0_x = dword_676818;
+    field_AC_cam_velocity.field_4_y = dword_676818;
+    field_AC_cam_velocity.field_8_z = dword_676818;
+    field_AC_cam_velocity.field_C_zoom = dword_676818;
 }
 
 MATCH_FUNC(0x435F90)
@@ -284,25 +287,32 @@ void DrawUnk_0xBC::sub_436860(s32 a2, s32* a3, s32* a4, s32 a5)
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x4368E0)
-DrawUnk_0xBC::DrawUnk_0xBC() // 4368E0
+MATCH_FUNC(0x4368E0)
+DrawUnk_0xBC::DrawUnk_0xBC()
 {
-    NOT_IMPLEMENTED;
+    field_68 = 0;
+    field_6C = 0;
+    sub_435830();
+    field_A4 = dword_6766D4;
+    sub_4397D0(-1, -1, -1, dword_6766D4);
+    ctor_inline(640, 480);
+    field_44 = 0;
+    sub_436830();
 }
 
-MATCH_FUNC(0x4369E0)
-DrawUnk_0xBC::~DrawUnk_0xBC() // empty 4369E0
+STUB_FUNC(0x4369E0)
+DrawUnk_0xBC::~DrawUnk_0xBC() // empty 4369E0   Why doesn't it match anymore?
 {
 }
 
 MATCH_FUNC(0x4397D0)
 void DrawUnk_0xBC::sub_4397D0(Fix16 a2, Fix16 a3, Fix16 a4, Fix16 a5)
 {
-    field_10_cam_pos_tgt2.field_0_x = a2;//field_10 = a2;
-    field_10_cam_pos_tgt2.field_4_y = a3;//field_14 = a3;
+    field_10_cam_pos_tgt2.field_0_x = a2;
+    field_10_cam_pos_tgt2.field_4_y = a3;
     a4 += field_40;
-    field_10_cam_pos_tgt2.field_8_z = a4;//field_18 = a4;
-    field_10_cam_pos_tgt2.field_C_zoom = a5;//field_1C = a5;
+    field_10_cam_pos_tgt2.field_8_z = a4;
+    field_10_cam_pos_tgt2.field_C_zoom = a5;
 }
 
 MATCH_FUNC(0x58CF10)

--- a/Source/DrawUnk_0xBC.cpp
+++ b/Source/DrawUnk_0xBC.cpp
@@ -56,25 +56,25 @@ GLOBAL(dword_676678, 0x676678);
 MATCH_FUNC(0x4357F0)
 void DrawUnk_0xBC::sub_4357F0()
 {
-    if (field_40 < dword_676894)
+    if (field_40_tgt_elevation < dword_676894)
     {
-        field_40 += dword_676678;
+        field_40_tgt_elevation += dword_676678;
     }
 }
 
 MATCH_FUNC(0x435810)
 void DrawUnk_0xBC::sub_435810()
 {
-    if (field_40 > dword_676818)
+    if (field_40_tgt_elevation > dword_676818)
     {
-        field_40 -= dword_676678;
+        field_40_tgt_elevation -= dword_676678;
     }
 }
 
 MATCH_FUNC(0x435830)
 void DrawUnk_0xBC::sub_435830()
 {
-    field_40 = dword_676818;
+    field_40_tgt_elevation = dword_676818;
 }
 
 EXPORT_VAR Fix16 dword_676898;
@@ -290,8 +290,8 @@ void DrawUnk_0xBC::sub_436860(s32 a2, s32* a3, s32* a4, s32 a5)
 MATCH_FUNC(0x4368E0)
 DrawUnk_0xBC::DrawUnk_0xBC()
 {
-    field_68 = 0;
-    field_6C = 0;
+    field_68_screen_px_width = 0;
+    field_6C_screen_px_height = 0;
     sub_435830();
     field_98_cam_pos2.field_C_zoom = dword_6766D4;
     sub_4397D0(-1, -1, -1, dword_6766D4);
@@ -310,7 +310,7 @@ void DrawUnk_0xBC::sub_4397D0(Fix16 a2, Fix16 a3, Fix16 a4, Fix16 a5)
 {
     field_10_cam_pos_tgt2.field_0_x = a2;
     field_10_cam_pos_tgt2.field_4_y = a3;
-    a4 += field_40;
+    a4 += field_40_tgt_elevation;
     field_10_cam_pos_tgt2.field_8_z = a4;
     field_10_cam_pos_tgt2.field_C_zoom = a5;
 }

--- a/Source/DrawUnk_0xBC.cpp
+++ b/Source/DrawUnk_0xBC.cpp
@@ -301,7 +301,7 @@ DrawUnk_0xBC::DrawUnk_0xBC()
 }
 
 STUB_FUNC(0x4369E0)
-DrawUnk_0xBC::~DrawUnk_0xBC() // empty 4369E0   Why doesn't it match anymore?
+DrawUnk_0xBC::~DrawUnk_0xBC() // empty 4369E0    Why doesn't it match anymore?
 {
 }
 

--- a/Source/DrawUnk_0xBC.cpp
+++ b/Source/DrawUnk_0xBC.cpp
@@ -15,6 +15,9 @@ GLOBAL(dword_676840, 0x676840);
 EXPORT_VAR Fix16 dword_67671C;
 GLOBAL(dword_67671C, 0x67671C);
 
+EXPORT_VAR Fix16 dword_676818;
+GLOBAL(dword_676818, 0x676818);
+
 EXPORT_VAR Fix16 dword_67681C;
 GLOBAL(dword_67681C, 0x67681C);
 
@@ -56,9 +59,6 @@ void DrawUnk_0xBC::sub_4357F0()
     }
 }
 
-EXPORT_VAR Fix16 dword_676818;
-GLOBAL(dword_676818, 0x676818);
-
 MATCH_FUNC(0x435810)
 void DrawUnk_0xBC::sub_435810()
 {
@@ -80,24 +80,24 @@ GLOBAL(dword_676898, 0x676898);
 MATCH_FUNC(0x435840)
 void DrawUnk_0xBC::sub_435840()
 {
-    if (field_18 < dword_676818)
+    if (field_10_cam_pos_tgt2.field_8_z < dword_676818)
     {
-        field_18 = dword_676818;
+        field_10_cam_pos_tgt2.field_8_z = dword_676818;
     }
 
-    if (field_18 > dword_676898)
+    if (field_10_cam_pos_tgt2.field_8_z > dword_676898)
     {
-        field_18 = dword_676898;
+        field_10_cam_pos_tgt2.field_8_z = dword_676898;
     }
 }
 
 MATCH_FUNC(0x435860)
 void DrawUnk_0xBC::sub_435860(DrawUnk_0xBC* a2)
 {
-    field_10 += a2->field_98_x - a2->field_88;
-    field_14 += a2->field_9C_y - a2->field_8C;
-    field_18 += a2->field_A0_z - a2->field_90;
-    field_1C += a2->field_A4 - a2->field_94;
+    field_10_cam_pos_tgt2.field_0_x += a2->field_98_x - a2->field_88;
+    field_10_cam_pos_tgt2.field_4_y += a2->field_9C_y - a2->field_8C;
+    field_10_cam_pos_tgt2.field_8_z += a2->field_A0_z - a2->field_90;
+    field_10_cam_pos_tgt2.field_C_zoom += a2->field_A4 - a2->field_94;
     sub_435840();
 }
 
@@ -138,39 +138,41 @@ STUB_FUNC(0x435D20)
 void DrawUnk_0xBC::sub_435D20(char_type a2, char_type a3, char_type a4, char_type a5, char_type a6, char_type a7)
 {
     NOT_IMPLEMENTED;
+    sub_41E410_reversed();
+    /*
     field_10 = field_0;
     field_14 = field_4_unk;
     field_18 = field_8;
     field_1C = field_C;
-
+    */
     if (a2)
     {
-        field_14 -= dword_67671C;
+        field_10_cam_pos_tgt2.field_4_y -= dword_67671C;//field_14 -= dword_67671C;
     }
 
     if (a3)
     {
-        field_14 += dword_67671C;
+        field_10_cam_pos_tgt2.field_4_y += dword_67671C;//field_14 += dword_67671C;
     }
 
     if (a4)
     {
-        field_10 -= dword_67671C;
+        field_10_cam_pos_tgt2.field_0_x -= dword_67671C;//field_10 -= dword_67671C;
     }
 
     if (a5)
     {
-        field_10 += dword_67671C;
+        field_10_cam_pos_tgt2.field_0_x += dword_67671C;//field_10 += dword_67671C;
     }
 
     if (a6)
     {
-        field_18 += dword_67681C;
+        field_10_cam_pos_tgt2.field_8_z += dword_67681C;//field_18 += dword_67681C;
     }
 
     if (a7)
     {
-        field_18 -= dword_67681C;
+        field_10_cam_pos_tgt2.field_8_z -= dword_67681C;//field_18 -= dword_67681C;
     }
 
     sub_435840();
@@ -179,10 +181,10 @@ void DrawUnk_0xBC::sub_435D20(char_type a2, char_type a3, char_type a4, char_typ
 MATCH_FUNC(0x435DD0)
 void DrawUnk_0xBC::sub_435DD0()
 {
-    field_98_x = field_0;
-    field_9C_y = field_4_unk;
-    field_A0_z = field_8;
-    field_A4 = field_C;
+    field_98_x = field_0_cam_pos_tgt1.field_0_x;//field_0;
+    field_9C_y = field_0_cam_pos_tgt1.field_4_y;//field_4_unk;
+    field_A0_z = field_0_cam_pos_tgt1.field_8_z;
+    field_A4 = field_0_cam_pos_tgt1.field_C_zoom;//field_C;
 
     field_AC = dword_676818;
     field_B0 = dword_676818;
@@ -304,11 +306,11 @@ DrawUnk_0xBC::~DrawUnk_0xBC() // empty 4369E0
 MATCH_FUNC(0x4397D0)
 void DrawUnk_0xBC::sub_4397D0(Fix16 a2, Fix16 a3, Fix16 a4, Fix16 a5)
 {
-    field_10 = a2;
-    field_14 = a3;
+    field_10_cam_pos_tgt2.field_0_x = a2;//field_10 = a2;
+    field_10_cam_pos_tgt2.field_4_y = a3;//field_14 = a3;
     a4 += field_40;
-    field_18 = a4;
-    field_1C = a5;
+    field_10_cam_pos_tgt2.field_8_z = a4;//field_18 = a4;
+    field_10_cam_pos_tgt2.field_C_zoom = a5;//field_1C = a5;
 }
 
 MATCH_FUNC(0x58CF10)

--- a/Source/DrawUnk_0xBC.hpp
+++ b/Source/DrawUnk_0xBC.hpp
@@ -2,9 +2,11 @@
 
 #include "Function.hpp"
 #include "fix16.hpp"
+#include "Car_BC.hpp"
 
 class Sprite;
 class Car_BC;
+class Car_8;
 class Ped;
 
 EXPORT_VAR extern Fix16 dword_676840;
@@ -72,8 +74,8 @@ class DrawUnk_0xBC
         Fix16 u = field_A0_z - z;
         Fix16 t(dword_67681C / Fix16(u.mValue + dword_676840.mValue, 0));
 
-        tmp.x = (((x - field_98_x) * field_64) * t) + Fix16(320);
-        tmp.y = (((y - field_9C_y) * field_64) * t) + Fix16(240);
+        tmp.x = (((x - field_98_x) * field_60.field_4) * t) + Fix16(320);
+        tmp.y = (((y - field_9C_y) * field_60.field_4) * t) + Fix16(240);
 
         return tmp;
     }
@@ -96,13 +98,29 @@ class DrawUnk_0xBC
         field_10_cam_pos_tgt2 = field_0_cam_pos_tgt1;
     }
 
+    inline void ctor_inline(s32 x, s32 y)
+    {
+        sub_41E410();
+        field_60.field_0 = Fix16(-1);
+        field_60.field_4 = Fix16(-1);
+        field_AC_cam_velocity.field_0_x = dword_676818;
+        field_AC_cam_velocity.field_4_y = dword_676818;
+        field_AC_cam_velocity.field_8_z = dword_676818;
+
+        field_3C = 0;
+        field_30 = dword_676818;
+        field_34 = 0;
+
+        sub_4361B0(x, y);
+    }
+
     CameraPos field_0_cam_pos_tgt1;
     CameraPos field_10_cam_pos_tgt2;
     s32 field_20_right;
     s32 field_24_left;
     s32 field_28_bottom;
     s32 field_2C_top;
-    s32 field_30;
+    Fix16 field_30;
     Ped* field_34;
     s32 field_38;
     s32 field_3C;
@@ -117,8 +135,8 @@ class DrawUnk_0xBC
     s32 field_54;
     s32 field_58;
     s32 field_5C;
-    s32 field_60;
-    Fix16 field_64;
+    Car_8 field_60;
+    //Fix16 field_64;
     s32 field_68;
     s32 field_6C;
     s32 field_70;
@@ -136,10 +154,7 @@ class DrawUnk_0xBC
     Fix16 field_A0_z;
     Fix16 field_A4;
     s32 field_A8;
-    Fix16 field_AC;
-    Fix16 field_B0;
-    Fix16 field_B4;
-    Fix16 field_B8;
+    CameraPos field_AC_cam_velocity;
 };
 GTA2_ASSERT_SIZEOF_ALWAYS(DrawUnk_0xBC, 0xBC)
 

--- a/Source/DrawUnk_0xBC.hpp
+++ b/Source/DrawUnk_0xBC.hpp
@@ -8,7 +8,24 @@ class Car_BC;
 class Ped;
 
 EXPORT_VAR extern Fix16 dword_676840;
+EXPORT_VAR extern Fix16 dword_676818;
 EXPORT_VAR extern Fix16 dword_67681C;
+
+struct CameraPos
+{
+    Fix16 field_0_x;
+    Fix16 field_4_y;
+    Fix16 field_8_z;
+    Fix16 field_C_zoom;
+};
+
+struct WorldRect
+{
+    Fix16 field_0_left;
+    Fix16 field_4_right;
+    Fix16 field_8_top;
+    Fix16 field_C_bottom;
+};
 
 class DrawUnk_0xBC
 {
@@ -69,14 +86,18 @@ class DrawUnk_0xBC
                  a3_fp <= field_84_win_bottom;
     }
 
-    Fix16 field_0;
-    Fix16 field_4_unk;
-    Fix16 field_8;
-    Fix16 field_C;
-    Fix16 field_10;
-    Fix16 field_14;
-    Fix16 field_18;
-    Fix16 field_1C;
+    inline void sub_41E410()
+    {
+        field_0_cam_pos_tgt1 = field_10_cam_pos_tgt2;
+    }
+
+    inline void sub_41E410_reversed()
+    {
+        field_10_cam_pos_tgt2 = field_0_cam_pos_tgt1;
+    }
+
+    CameraPos field_0_cam_pos_tgt1;
+    CameraPos field_10_cam_pos_tgt2;
     s32 field_20_right;
     s32 field_24_left;
     s32 field_28_bottom;

--- a/Source/DrawUnk_0xBC.hpp
+++ b/Source/DrawUnk_0xBC.hpp
@@ -65,7 +65,7 @@ class DrawUnk_0xBC
 
     inline void inline_sub_475B60()
     {
-        field_3C = 1;
+        field_3C_followed_ped_id = 1;
     }
 
     Fix16_Point sub_40CFC0(Fix16 x, Fix16 y, Fix16 z)
@@ -108,9 +108,9 @@ class DrawUnk_0xBC
         field_AC_cam_velocity.field_4_y = dword_676818;
         field_AC_cam_velocity.field_8_z = dword_676818;
 
-        field_3C = 0;
+        field_3C_followed_ped_id = 0;
         field_30 = dword_676818;
-        field_34 = 0;
+        field_34_ped = NULL;
 
         sub_4361B0(x, y);
     }
@@ -119,10 +119,10 @@ class DrawUnk_0xBC
     CameraPos field_10_cam_pos_tgt2;
     WorldRect field_20_boundaries;
     Fix16 field_30;
-    Ped* field_34;
-    s32 field_38;
-    s32 field_3C;
-    Fix16 field_40;
+    Ped* field_34_ped;
+    Car_BC *field_38_car;
+    s32 field_3C_followed_ped_id;
+    Fix16 field_40_tgt_elevation;
     u8 field_44;
     char_type field_45;
     char_type field_46;
@@ -134,14 +134,14 @@ class DrawUnk_0xBC
     s32 field_58;
     s32 field_5C;
     Car_8 field_60;
-    s32 field_68;
-    s32 field_6C;
-    s32 field_70;
-    s32 field_74;
+    s32 field_68_screen_px_width;
+    s32 field_6C_screen_px_height;
+    s32 field_70_screen_px_center_x;
+    s32 field_74_screen_px_center_y;
     WorldRect field_78_boundaries_non_neg;
     CameraPos field_88_cam_pos1;
     CameraPos field_98_cam_pos2;
-    s32 field_A8;
+    s32 field_A8_ui_scale;
     CameraPos field_AC_cam_velocity;
 };
 GTA2_ASSERT_SIZEOF_ALWAYS(DrawUnk_0xBC, 0xBC)

--- a/Source/DrawUnk_0xBC.hpp
+++ b/Source/DrawUnk_0xBC.hpp
@@ -71,11 +71,11 @@ class DrawUnk_0xBC
     Fix16_Point sub_40CFC0(Fix16 x, Fix16 y, Fix16 z)
     {
         Fix16_Point tmp;
-        Fix16 u = field_A0_z - z;
+        Fix16 u = field_98_cam_pos2.field_8_z - z;
         Fix16 t(dword_67681C / Fix16(u.mValue + dword_676840.mValue, 0));
 
-        tmp.x = (((x - field_98_x) * field_60.field_4) * t) + Fix16(320);
-        tmp.y = (((y - field_9C_y) * field_60.field_4) * t) + Fix16(240);
+        tmp.x = (((x - field_98_cam_pos2.field_0_x) * field_60.field_4) * t) + Fix16(320);
+        tmp.y = (((y - field_98_cam_pos2.field_4_y) * field_60.field_4) * t) + Fix16(240);
 
         return tmp;
     }
@@ -83,9 +83,10 @@ class DrawUnk_0xBC
     // inline sub_40CF60
     inline bool check_camera(Fix16 a2_fp, Fix16 a3_fp)
     {
-        return a2_fp >= field_78_win_left && a2_fp <= field_7C_win_right &&
-                 a3_fp >= field_80_win_top &&
-                 a3_fp <= field_84_win_bottom;
+        return a2_fp >= field_78_boundaries_non_neg.field_0_left && 
+                a2_fp <= field_78_boundaries_non_neg.field_4_right &&
+                a3_fp >= field_78_boundaries_non_neg.field_8_top &&
+                a3_fp <= field_78_boundaries_non_neg.field_C_bottom;
     }
 
     inline void sub_41E410()
@@ -116,10 +117,7 @@ class DrawUnk_0xBC
 
     CameraPos field_0_cam_pos_tgt1;
     CameraPos field_10_cam_pos_tgt2;
-    s32 field_20_right;
-    s32 field_24_left;
-    s32 field_28_bottom;
-    s32 field_2C_top;
+    WorldRect field_20_boundaries;
     Fix16 field_30;
     Ped* field_34;
     s32 field_38;
@@ -136,23 +134,13 @@ class DrawUnk_0xBC
     s32 field_58;
     s32 field_5C;
     Car_8 field_60;
-    //Fix16 field_64;
     s32 field_68;
     s32 field_6C;
     s32 field_70;
     s32 field_74;
-    Fix16 field_78_win_left;
-    Fix16 field_7C_win_right;
-    Fix16 field_80_win_top;
-    Fix16 field_84_win_bottom;
-    Fix16 field_88;
-    Fix16 field_8C;
-    Fix16 field_90;
-    Fix16 field_94;
-    Fix16 field_98_x;
-    Fix16 field_9C_y;
-    Fix16 field_A0_z;
-    Fix16 field_A4;
+    WorldRect field_78_boundaries_non_neg;
+    CameraPos field_88_cam_pos1;
+    CameraPos field_98_cam_pos2;
     s32 field_A8;
     CameraPos field_AC_cam_velocity;
 };

--- a/Source/Game_0x40.cpp
+++ b/Source/Game_0x40.cpp
@@ -715,7 +715,10 @@ void Game_0x40::sub_4B9790(Fix16 a2, Fix16 a3, Fix16 a4)
     DrawUnk_0xBC* pCam = IteratePlayerCamera_4B9BC0();
     while (pCam)
     {
-        if (a3 >= pCam->field_78_win_left && a3 <= pCam->field_7C_win_right && a4 >= pCam->field_80_win_top && a4 <= pCam->field_84_win_bottom)
+        if (a3 >= pCam->field_78_boundaries_non_neg.field_0_left 
+            && a3 <= pCam->field_78_boundaries_non_neg.field_4_right 
+            && a4 >= pCam->field_78_boundaries_non_neg.field_8_top 
+            && a4 <= pCam->field_78_boundaries_non_neg.field_C_bottom)
         {
             pCam->sub_436120(a2);
         }
@@ -832,17 +835,18 @@ s8 Game_0x40::sub_4B9B10(Fix16_Rect* pBounds)
         Player* pCurPlayer = field_4_players[i];
         if (pCurPlayer->field_8E_bInUse)
         {
-            if (pBounds->field_8_top <= pCurPlayer->field_90_game_camera.field_2C_top &&
-                pBounds->field_C_bottom >= pCurPlayer->field_90_game_camera.field_28_bottom &&
-                pBounds->field_0_left <= pCurPlayer->field_90_game_camera.field_24_left &&
-                pBounds->field_4_right >= pCurPlayer->field_90_game_camera.field_20_right)
+            if (pBounds->field_8_top <= pCurPlayer->field_90_game_camera.field_20_boundaries.field_C_bottom &&
+                pBounds->field_C_bottom >= pCurPlayer->field_90_game_camera.field_20_boundaries.field_8_top &&
+                pBounds->field_0_left <= pCurPlayer->field_90_game_camera.field_20_boundaries.field_4_right &&
+                pBounds->field_4_right >= pCurPlayer->field_90_game_camera.field_20_boundaries.field_0_left)
             {
                 return 1;
             }
-            if (pCurPlayer->field_2D0 && pBounds->field_8_top <= pCurPlayer->field_208_aux_game_camera.field_2C_top &&
-                pBounds->field_C_bottom >= pCurPlayer->field_208_aux_game_camera.field_28_bottom &&
-                pBounds->field_0_left <= pCurPlayer->field_208_aux_game_camera.field_24_left &&
-                pBounds->field_4_right >= pCurPlayer->field_208_aux_game_camera.field_20_right)
+            if (pCurPlayer->field_2D0 &&
+                pBounds->field_8_top <= pCurPlayer->field_208_aux_game_camera.field_20_boundaries.field_C_bottom &&
+                pBounds->field_C_bottom >= pCurPlayer->field_208_aux_game_camera.field_20_boundaries.field_8_top &&
+                pBounds->field_0_left <= pCurPlayer->field_208_aux_game_camera.field_20_boundaries.field_4_right &&
+                pBounds->field_4_right >= pCurPlayer->field_208_aux_game_camera.field_20_boundaries.field_0_left)
             {
                 return 1;
             }

--- a/Source/ImGuiDebug.cpp
+++ b/Source/ImGuiDebug.cpp
@@ -16,6 +16,7 @@
 #include "gbh_graphics.hpp"
 #include "Frontend.hpp"
 #include "jolly_poitras_0x2BC0.hpp"
+#include "Phi_8CA8.hpp"
 #include <stdarg.h>
 
 extern EXPORT_VAR Ambulance_110* gAmbulance_110_6F70A8;
@@ -136,16 +137,17 @@ void CC ImGuiDebugDraw()
         {
             if (gViewCamera_676978)
             {
-                ImGui::Text("field_78_win_left %f", gViewCamera_676978->field_78_win_left.ToFloat());
-                ImGui::Text("field_7C_right %f", gViewCamera_676978->field_7C_win_right.ToFloat());
-                ImGui::Text("field_80_win_top %f", gViewCamera_676978->field_80_win_top.ToFloat());
-                ImGui::Text("field_84_win_bottom %f", gViewCamera_676978->field_84_win_bottom.ToFloat());
+                ImGui::Text("field_78_win_left %f", gViewCamera_676978->field_78_boundaries_non_neg.field_0_left.ToFloat());
+                ImGui::Text("field_7C_right %f", gViewCamera_676978->field_78_boundaries_non_neg.field_4_right.ToFloat());
+                ImGui::Text("field_80_win_top %f", gViewCamera_676978->field_78_boundaries_non_neg.field_8_top.ToFloat());
+                ImGui::Text("field_84_win_bottom %f", gViewCamera_676978->field_78_boundaries_non_neg.field_C_bottom.ToFloat());
+                ImGui::SliderInt("field_A4", &gViewCamera_676978->field_98_cam_pos2.field_C_zoom.mValue, 0, 30000);
             }
 
             if (ImGui::Button("Orca_2FD4::sub_5552B0"))
             {
-                char xpos = gViewCamera_676978->field_78_win_left.ToInt() + 5;
-                char ypos = gViewCamera_676978->field_80_win_top.ToInt() + 5;
+                char xpos = gViewCamera_676978->field_78_boundaries_non_neg.field_0_left.ToInt() + 5;
+                char ypos = gViewCamera_676978->field_78_boundaries_non_neg.field_8_top.ToInt() + 5;
                 char zpos = 2;
                 if (gOrca_2FD4_6FDEF0->sub_5552B0(0, &xpos, &ypos, &zpos, 1))
                 {
@@ -166,7 +168,7 @@ void CC ImGuiDebugDraw()
                     //DrawUnk_0xBC* aux_camera = &pPlayer->field_208_aux_game_camera;
                     if (game_camera)
                     {
-                        ImGui::SliderInt("field_A4", &game_camera->field_A4.mValue, 0, 25000);
+                        ImGui::SliderInt("field_A4", &game_camera->field_98_cam_pos2.field_C_zoom.mValue, 0, 25000);
                     }
                 }
             }
@@ -652,6 +654,45 @@ void CC ImGuiDebugDraw()
             {
                 Hamburger_40& hb = gHamburger_500_678E30->field_0[i];
                 ImGui::Value("field_0", hb.field_0);
+            }
+        }
+        ImGui::TreePop();
+    }
+
+    if (ImGui::TreeNode("gPhi_8CA8_6FCF00"))
+    {
+        if (gPhi_8CA8_6FCF00)
+        {
+            ImGui::Value("field_0_next_idx", gPhi_8CA8_6FCF00->field_0_next_idx);
+            ImGui::Value("field_2", gPhi_8CA8_6FCF00->field_2);
+            ImGui::Value("field_8CA4", gPhi_8CA8_6FCF00->field_8CA4);
+            ImGui::Value("field_8CA6", gPhi_8CA8_6FCF00->field_8CA6);
+
+            static s32 phi_74_id = 0;
+            ImGui::SliderInt("Phi_74 id", &phi_74_id, 0, 299);
+            Phi_74* phi = gPhi_8CA8_6FCF00->field_87F4[phi_74_id];
+            if (phi)
+            {
+                ImGui::Value("field_0", phi->field_0.mValue);
+                ImGui::Value("field_4", phi->field_4.mValue);
+                ImGui::Value("field_8", phi->field_8.mValue);
+                ImGui::Value("field_C", phi->field_C.mValue);
+                ImGui::Value("field_10", phi->field_10.mValue);
+                ImGui::Value("field_14", phi->field_14.mValue);
+                ImGui::Value("field_18", phi->field_18.mValue);
+                ImGui::SliderS16("field_1C_remap", &phi->field_1C_remap, 0, 50);
+                ImGui::Value("field_20", phi->field_20);
+                ImGui::Value("field_21", phi->field_21);
+                ImGui::Value("field_22", phi->field_22);
+                ImGui::Value("field_23", phi->field_23);
+                ImGui::Value("field_24_idx", phi->field_24_idx);
+                ImGui::Value("field_28", phi->field_28);
+
+                ImGui::Value("field_6C", phi->field_6C);
+                ImGui::Value("field_6D", phi->field_6D);
+                ImGui::Value("field_6E", phi->field_6E);
+                ImGui::Value("field_6F", phi->field_6F);
+                ImGui::Value("field_70", phi->field_70);
             }
         }
         ImGui::TreePop();

--- a/Source/Kfc_1E0.hpp
+++ b/Source/Kfc_1E0.hpp
@@ -33,7 +33,7 @@ class Kfc_30
     char_type field_1F;
     s32 field_20;
     s32 field_24;
-    Ped* field_28;
+    s32 field_28;
     char_type field_2C;
     char_type field_2D;
     char_type field_2E;

--- a/Source/MapRenderer.cpp
+++ b/Source/MapRenderer.cpp
@@ -100,8 +100,8 @@ void MapRenderer::set_vert_xyz_relative_to_cam_4EAD90(Fix16 xCoord, Fix16 yCoord
 
     s32 next_idx = (pVerts - gTileVerts_6F65A8) + 4;
 
-    gTileVerts_6F65A8[next_idx].x = (xCoord + pCam->field_98_x).ToFloat();
-    gTileVerts_6F65A8[next_idx].y = (yCoord + pCam->field_9C_y).ToFloat();
+    gTileVerts_6F65A8[next_idx].x = (xCoord + pCam->field_98_cam_pos2.field_0_x).ToFloat();
+    gTileVerts_6F65A8[next_idx].y = (yCoord + pCam->field_98_cam_pos2.field_4_y).ToFloat();
     gTileVerts_6F65A8[next_idx].z = z_val.ToFloat();
 }
 
@@ -353,8 +353,8 @@ void MapRenderer::sub_4F6880(s32& pXCoord, s32& pYCoord)
                 gBlockBottom_6F6468 = gBlockBottom_6F6468 | 0x260;
             }
         }
-        gXCoord_6F63AC = Fix16(pXCoord) - gViewCamera_676978->field_98_x;
-        gYCoord_6F63B8 = Fix16(pYCoord) - gViewCamera_676978->field_9C_y;
+        gXCoord_6F63AC = Fix16(pXCoord) - gViewCamera_676978->field_98_cam_pos2.field_0_x;
+        gYCoord_6F63B8 = Fix16(pYCoord) - gViewCamera_676978->field_98_cam_pos2.field_4_y;
         
         u8 v6 = pBlock->field_B_slope_type & 0xFC;
         

--- a/Source/PedGroup.hpp
+++ b/Source/PedGroup.hpp
@@ -42,7 +42,7 @@ class PedGroup
     EXPORT bool sub_4CAD40();
     EXPORT Ped* sub_4CAE80(u8 idx);
     EXPORT static void sub_4CB080();
-    EXPORT PedGroup* sub_4CB0D0();
+    EXPORT static PedGroup* sub_4CB0D0();
     EXPORT PedGroup();
     EXPORT ~PedGroup();
 

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -904,7 +904,7 @@ void Player::sub_5695A0()
         field_2C8_unkq = 0;
         field_2CC = 0;
         field_2D0 = 0;
-        field_90_game_camera.field_3C = 1;
+        field_90_game_camera.field_3C_followed_ped_id = 1;
     }
 }
 

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -919,17 +919,14 @@ STUB_FUNC(0x5696D0)
 void Player::sub_5696D0(Car_BC* pCar)
 {
     NOT_IMPLEMENTED;
-    if (!this->field_2D0 && !this->field_2C8_unkq && !this->field_2CC)
+    if (!field_2D0 && !field_2C8_unkq && !field_2CC)
     {
-        this->field_2CC = pCar;
-        this->field_208_aux_game_camera.sub_4364A0(pCar);
-        this->field_208_aux_game_camera.field_0 = this->field_208_aux_game_camera.field_10;
-        this->field_208_aux_game_camera.field_4_unk = this->field_208_aux_game_camera.field_14;
-        this->field_208_aux_game_camera.field_8 = this->field_208_aux_game_camera.field_18;
-        this->field_208_aux_game_camera.field_C = this->field_208_aux_game_camera.field_1C;
-        this->field_208_aux_game_camera.sub_435DD0();
-        this->field_68 = 3;
-        this->field_2D0 = 1;
+        field_2CC = pCar;
+        field_208_aux_game_camera.sub_4364A0(pCar);
+        field_208_aux_game_camera.field_0_cam_pos_tgt1 = field_208_aux_game_camera.field_10_cam_pos_tgt2;
+        field_208_aux_game_camera.sub_435DD0();
+        field_68 = 3;
+        field_2D0 = 1;
     }
 }
 

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -563,22 +563,17 @@ char_type Player::sub_566C80(u32* a2)
     return 'a';
 }
 
-STUB_FUNC(0x566EE0)
+MATCH_FUNC(0x566EE0)
 void Player::sub_566EE0(char_type bDoNothing)
 {
-    NOT_IMPLEMENTED;
-    Ped* pPed; // eax
-    Car_BC* pCar; // edi
-    Car_B0* pPhysics; // ecx
-
     if (!bDoNothing)
     {
-        pPed = Get_Field_68_Ped();
-        pCar = pPed->field_16C_car;
+        Ped* pPed = Get_Field_68_Ped();
+        Car_BC* pCar = pPed->field_16C_car;
 
         if (pCar)
         {
-            pPhysics = pCar->field_58_uni_Car78_or_Car_B0;
+            Car_B0* pPhysics = pCar->field_58_uni_Car78_or_Car_B0;
             if (pPhysics)
             {
                 pPhysics->sub_559430();
@@ -589,24 +584,24 @@ void Player::sub_566EE0(char_type bDoNothing)
         if (bDo_show_camera_67D58A)
         {
             // fmuls vs fmull
-            float x = this->field_90_game_camera.field_98_x.ToFloat();
-            float y = this->field_90_game_camera.field_9C_y.ToFloat();
-            float z = this->field_90_game_camera.field_A0_z.ToFloat();
+            double x = this->field_90_game_camera.field_98_x.AsDouble();
+            double y = this->field_90_game_camera.field_9C_y.AsDouble();
+            double z = this->field_90_game_camera.field_A0_z.AsDouble();
             swprintf(tmpBuff_67BD9C, L"game camera: (%3.3f,%3.3f,%3.3f)", x, y, z);
             gGarox_2B00_706620->field_650.sub_5D1F50(tmpBuff_67BD9C, 0, 64, word_706600, 1);
 
             swprintf(tmpBuff_67BD9C,
                      L"aux game camera: (%3.3f,%3.3f,%3.3f)",
-                     this->field_208_aux_game_camera.field_98_x.ToFloat(),
-                     this->field_208_aux_game_camera.field_9C_y.ToFloat(),
-                     this->field_208_aux_game_camera.field_A0_z.ToFloat());
+                     this->field_208_aux_game_camera.field_98_x.AsDouble(),
+                     this->field_208_aux_game_camera.field_9C_y.AsDouble(),
+                     this->field_208_aux_game_camera.field_A0_z.AsDouble());
             gGarox_2B00_706620->field_650.sub_5D1F50(tmpBuff_67BD9C, 0, 80, word_706600, 1);
 
             swprintf(tmpBuff_67BD9C,
                      L"view camera: (%3.3f,%3.3f,%3.3f)",
-                     this->field_14C_view_camera.field_98_x.ToFloat(),
-                     this->field_14C_view_camera.field_9C_y.ToFloat(),
-                     this->field_14C_view_camera.field_A0_z.ToFloat());
+                     this->field_14C_view_camera.field_98_x.AsDouble(),
+                     this->field_14C_view_camera.field_9C_y.AsDouble(),
+                     this->field_14C_view_camera.field_A0_z.AsDouble());
             gGarox_2B00_706620->field_650.sub_5D1F50(tmpBuff_67BD9C, 0, 96, word_706600, 1);
         }
 

--- a/Source/Player.cpp
+++ b/Source/Player.cpp
@@ -367,9 +367,9 @@ void Player::sub_565310()
 MATCH_FUNC(0x5653E0)
 void Player::sub_5653E0()
 {
-    Car_BC* pCar = gCar_6C_677930->sub_444FA0(this->field_14C_view_camera.field_98_x,
-                                              this->field_14C_view_camera.field_9C_y,
-                                              this->field_14C_view_camera.field_A0_z,
+    Car_BC* pCar = gCar_6C_677930->sub_444FA0(field_14C_view_camera.field_98_cam_pos2.field_0_x,
+                                              field_14C_view_camera.field_98_cam_pos2.field_4_y,
+                                              field_14C_view_camera.field_98_cam_pos2.field_8_z,
                                               0);
     if (pCar)
     {
@@ -584,24 +584,24 @@ void Player::sub_566EE0(char_type bDoNothing)
         if (bDo_show_camera_67D58A)
         {
             // fmuls vs fmull
-            double x = this->field_90_game_camera.field_98_x.AsDouble();
-            double y = this->field_90_game_camera.field_9C_y.AsDouble();
-            double z = this->field_90_game_camera.field_A0_z.AsDouble();
+            double x = this->field_90_game_camera.field_98_cam_pos2.field_0_x.AsDouble();
+            double y = this->field_90_game_camera.field_98_cam_pos2.field_4_y.AsDouble();
+            double z = this->field_90_game_camera.field_98_cam_pos2.field_8_z.AsDouble();
             swprintf(tmpBuff_67BD9C, L"game camera: (%3.3f,%3.3f,%3.3f)", x, y, z);
             gGarox_2B00_706620->field_650.sub_5D1F50(tmpBuff_67BD9C, 0, 64, word_706600, 1);
 
             swprintf(tmpBuff_67BD9C,
                      L"aux game camera: (%3.3f,%3.3f,%3.3f)",
-                     this->field_208_aux_game_camera.field_98_x.AsDouble(),
-                     this->field_208_aux_game_camera.field_9C_y.AsDouble(),
-                     this->field_208_aux_game_camera.field_A0_z.AsDouble());
+                     this->field_208_aux_game_camera.field_98_cam_pos2.field_0_x.AsDouble(),
+                     this->field_208_aux_game_camera.field_98_cam_pos2.field_4_y.AsDouble(),
+                     this->field_208_aux_game_camera.field_98_cam_pos2.field_8_z.AsDouble());
             gGarox_2B00_706620->field_650.sub_5D1F50(tmpBuff_67BD9C, 0, 80, word_706600, 1);
 
             swprintf(tmpBuff_67BD9C,
                      L"view camera: (%3.3f,%3.3f,%3.3f)",
-                     this->field_14C_view_camera.field_98_x.AsDouble(),
-                     this->field_14C_view_camera.field_9C_y.AsDouble(),
-                     this->field_14C_view_camera.field_A0_z.AsDouble());
+                     this->field_14C_view_camera.field_98_cam_pos2.field_0_x.AsDouble(),
+                     this->field_14C_view_camera.field_98_cam_pos2.field_4_y.AsDouble(),
+                     this->field_14C_view_camera.field_98_cam_pos2.field_8_z.AsDouble());
             gGarox_2B00_706620->field_650.sub_5D1F50(tmpBuff_67BD9C, 0, 96, word_706600, 1);
         }
 

--- a/Source/PurpleDoom.cpp
+++ b/Source/PurpleDoom.cpp
@@ -56,10 +56,10 @@ static inline s32 Clamp(s32 value, s32 min, s32 max)
 MATCH_FUNC(0x477a40)
 void PurpleDoom::DrawSpritesClipped_477A40()
 {
-    const s32 left = Clamp((gViewCamera_676978->field_78_win_left - dword_679084).ToInt(), 0, 255);
-    const s32 right_val = Clamp((dword_678F80 + gViewCamera_676978->field_7C_win_right).ToInt(), 0, 255);
-    const s32 top_val = Clamp((gViewCamera_676978->field_80_win_top - dword_679084).ToInt(), 0, 255);
-    const s32 bottom_val = Clamp((dword_678F80 + gViewCamera_676978->field_84_win_bottom).ToInt(), 0, 255);
+    const s32 left = Clamp((gViewCamera_676978->field_78_boundaries_non_neg.field_0_left - dword_679084).ToInt(), 0, 255);
+    const s32 right_val = Clamp((dword_678F80 + gViewCamera_676978->field_78_boundaries_non_neg.field_4_right).ToInt(), 0, 255);
+    const s32 top_val = Clamp((gViewCamera_676978->field_78_boundaries_non_neg.field_8_top - dword_679084).ToInt(), 0, 255);
+    const s32 bottom_val = Clamp((dword_678F80 + gViewCamera_676978->field_78_boundaries_non_neg.field_C_bottom).ToInt(), 0, 255);
 
     AddToDrawList_478240(left, right_val, top_val, bottom_val);
 }

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -312,10 +312,110 @@ void miss2_0x11C::SCRCMD_PLAYER_PED_503A20(SCR_PLAYER_PED* pCmd)
     }
 }
 
-STUB_FUNC(0x503bc0)
-void miss2_0x11C::SCRCMD_CAR_DECSET_503BC0(SCR_CAR_DATA_DEC* a1, SCR_POINTER* a2)
+MATCH_FUNC(0x503bc0)
+void miss2_0x11C::SCRCMD_CAR_DECSET_503BC0(SCR_CAR_DATA_DEC* pCmd, SCR_POINTER* pPointer)
 {
-    NOT_IMPLEMENTED;
+    if (pCmd->field_C_pos.field_8_z == dword_6F7570) //  255.0
+    {
+        Fix16 temp_z;
+        pCmd->field_C_pos.field_8_z =
+            *gMap_0x370_6F6268->FindGroundZForCoord_4E5B60(&temp_z, pCmd->field_C_pos.field_0_x, pCmd->field_C_pos.field_4_y);
+    }
+    if (pCmd->field_1E_trailer_id == -1) //  No trailers
+    {
+        Ang16 rotation;
+        rotation.ConvertAndMultiply(&word_6F8044, &pCmd->field_18_rot);
+        rotation.sub_406C20();
+        pPointer->field_8_car = gCar_6C_677930->sub_426E10(pCmd->field_C_pos.field_0_x,
+                                                           pCmd->field_C_pos.field_4_y,
+                                                           pCmd->field_C_pos.field_8_z,
+                                                           rotation,
+                                                           pCmd->field_1C_car_id);
+    }
+    else if (pCmd->field_1E_trailer_id == -2) //  Mini car
+    {
+        Ang16 rotation;
+        rotation.ConvertAndMultiply(&word_6F8044, &pCmd->field_18_rot);
+        rotation.sub_406C20();
+        pPointer->field_8_car = gCar_6C_677930->sub_4764A0(pCmd->field_C_pos.field_0_x,
+                                                           pCmd->field_C_pos.field_4_y,
+                                                           pCmd->field_C_pos.field_8_z,
+                                                           rotation,
+                                                           pCmd->field_1C_car_id);
+        if (pPointer->field_8_car != NULL)
+        {
+            pPointer->field_8_car->field_98 = 4;
+            pPointer->field_8_car->field_78_flags |= 0x10u;
+            pPointer->field_8_car->sub_4435F0();
+        }
+    }
+    else //  There is a trailer
+    {
+        if (pCmd->field_1C_car_id == car_model_enum::TRUKTRNS) // 66 = TRUKTRNS Truck Trailer, Flatbed
+        {
+            Car_BC* v7 = gCar_6C_677930->sub_446230_shortened(pCmd->field_1E_trailer_id);
+            Ang16 rotation;
+            rotation.ConvertAndMultiply(&word_6F8044, &pCmd->field_18_rot);
+            rotation.Normalize();
+
+            pPointer->field_8_car = gCar_6C_677930->sub_426E10(pCmd->field_C_pos.field_0_x,
+                                                               pCmd->field_C_pos.field_4_y,
+                                                               pCmd->field_C_pos.field_8_z,
+                                                               rotation,
+                                                               pCmd->field_1C_car_id);
+            pPointer->field_8_car->field_50_car_sprite->sub_5A3100(v7->field_50_car_sprite, dword_6F77C0, dword_6F77C0, word_6F771E);
+            v7->IncrementCarStats_443D70(8);
+        }
+        else
+        {
+            Ang16 rotation;
+            rotation.ConvertAndMultiply(&word_6F8044, &pCmd->field_18_rot);
+            rotation.Normalize();
+
+            Car_A4_10* v11 = gCar_6C_677930->sub_446530(pCmd->field_C_pos.field_0_x,
+                                                        pCmd->field_C_pos.field_4_y,
+                                                        rotation,
+                                                        pCmd->field_1C_car_id,
+                                                        pCmd->field_1E_trailer_id);
+            if (v11 != NULL)
+            {
+                pPointer->field_8_car = v11->field_8;
+            }
+            else
+            {
+                pPointer->field_8_car = NULL;
+            }
+        }
+    }
+    if (pPointer->field_8_car != NULL)
+    {
+        if (pCmd->field_1A_remap != -1)
+        {
+            pPointer->field_8_car->SetCarRemap(pCmd->field_1A_remap);
+        }
+
+        Car_BC* v12 = pPointer->field_8_car;
+        v12->field_7C_uni_num = 5;
+        v12->field_76 = 0;
+
+        if (pPointer->field_8_car->field_98 != 4)
+        {
+            pPointer->field_8_car->field_98 = 2;
+        }
+        pPointer->field_8_car->IncrementCarStats_443D70(8);
+        pPointer->field_8_car->field_50_car_sprite->sub_5A2A30();
+
+        if (pCmd->field_2_type >= 0x18Au //  create gang car
+            && pCmd->field_2_type <= 0x18Du)
+        {
+            s8 zone_idx = gZones_CA8_67E274->sub_4BF2F0(pPointer->field_8_car->field_84_car_info_idx);
+            if (zone_idx > -1)
+            {
+                Gang_144* pZone = gZones_CA8_67E274->ZoneByIdx_4BF1C0(zone_idx);
+                pPointer->field_8_car->sub_440660(pZone->field_138_arrow_colour);
+            }
+        }
+    }
 }
 
 MATCH_FUNC(0x503f80)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -2617,10 +2617,27 @@ void miss2_0x11C::sub_50B690()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50b6f0)
+MATCH_FUNC(0x50b6f0)
 void miss2_0x11C::SCRCMD_CHECK_SCORE_50B6F0()
 {
-    NOT_IMPLEMENTED;
+    SCR_CHECK_SCORE_GREATER* pCmd = (SCR_CHECK_SCORE_GREATER*)gBasePtr_6F8070;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+    Ped* pPed = pPointer->field_8_char;
+
+    if (pPed != NULL)
+    {
+        Player* pPlayer = pPed->field_15C_player;
+        if (pPlayer != NULL 
+            && pPlayer->field_2D4_unk.sub_592370() > pCmd->field_C_target_score)
+        {
+            field_8 = true;
+        }
+        else
+        {
+            field_8 = false;
+        }
+    }
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 STUB_FUNC(0x50b760)

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -401,6 +401,12 @@ struct SCR_IS_CAR_IN_BLOCK : SCR_CMD_HEADER
     SCR_XYZ_f field_C_pos;
 };
 
+struct SCR_CHECK_SCORE_GREATER : SCR_CMD_HEADER
+{
+    u32 field_8_unknown;
+    s32 field_C_target_score;
+};
+
 namespace SCR_DOOR_OPENTYPES
 {
 enum

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -78,10 +78,10 @@ struct SCR_CAR_DATA_DEC : SCR_CMD_HEADER
     u16 field_8_car_idx;
     u16 field_A_unk;
     SCR_XYZ_f field_C_pos;
-    u16 field_18_rot;
-    u16 field_1A_remap;
+    Ang16 field_18_rot;
+    s16 field_1A_remap;
     s16 field_1C_car_id;
-    u16 field_1E_trailer_id;
+    s16 field_1E_trailer_id;
 };
 
 struct SCR_CHAR_DATA_DEC : SCR_CMD_HEADER
@@ -427,6 +427,9 @@ enum
 };
 //static_assert(sizeof(SCR_DOOR_CLOSETYPES) == 1)
 } // namespace SCR_DOOR_CLOSETYPES
+
+EXPORT_VAR extern Fix16 dword_6F77C0;
+EXPORT_VAR extern Fix16 dword_6F77C4;
 
 class miss2_0x11C
 {

--- a/Source/sound_obj.cpp
+++ b/Source/sound_obj.cpp
@@ -427,7 +427,7 @@ void sound_obj::InterrogateAudioEntities_41A730()
 
     if (field_1478_type5Idx != 0 && (field_C_pAny = (DrawUnk_0xBC*)field_147C[field_1478_type5Idx].field_4_pObj->field_C_pAny) != NULL)
     {
-        Ped* v4 = field_C_pAny->field_34;
+        Ped* v4 = field_C_pAny->field_34_ped;
 
         if (v4 != NULL)
         {

--- a/Source/sound_obj.cpp
+++ b/Source/sound_obj.cpp
@@ -449,9 +449,9 @@ void sound_obj::InterrogateAudioEntities_41A730()
         }
         else
         {
-            field_1468_v1 = field_C_pAny->field_98_x;
-            field_146C_v2 = field_C_pAny->field_9C_y;
-            field_1470_v3 = field_C_pAny->field_A0_z;
+            field_1468_v1 = field_C_pAny->field_98_cam_pos2.field_0_x;
+            field_146C_v2 = field_C_pAny->field_98_cam_pos2.field_4_y;
+            field_1470_v3 = field_C_pAny->field_98_cam_pos2.field_8_z;
         }
     }
     else


### PR DESCRIPTION
match Ambulance_20::sub_4FA820
match Player::sub_566EE0
match miss2_0x11C::SCRCMD_CAR_DECSET_503BC0
match miss2_0x11C::SCRCMD_CHECK_SCORE_50B6F0
match DrawUnk_0xBC::ctor_4368E0
match DrawUnk_0xBC::sub_435D20

stub DrawUnk_0xBC_dtor_4369E0 (maybe Car_8 issue)

# DrawUnk_0xBC field renames:

CameraPos field_0_cam_pos_tgt1;
CameraPos field_10_cam_pos_tgt2;
WorldRect field_20_boundaries;

field_34 -> field_34_ped
field_38 -> field_38_car
field_3C -> field_3C_followed_ped_id
field_40 -> field_40_tgt_elevation

field_68 -> field_68_screen_px_width
field_6C -> field_6C_screen_px_height;
field_70 -> field_70_screen_px_center_x;
field_74 -> field_74_screen_px_center_y;

CameraPos field_88_cam_pos1;
CameraPos field_98_cam_pos2;

field_A8 -> field_A8_ui_scale

CameraPos field_AC_cam_velocity;