### PR TITLE
Script matches & Fix decompme HTTP request

### DIFF
--- a/Scripts/generate_function_decompme.py
+++ b/Scripts/generate_function_decompme.py
@@ -307,6 +307,7 @@ def main():
         "https://decomp.me/api/scratch",
         headers={
             "Content-Type": "application/json",
+            "User-Agent": "python-requests/2.28.2",
         },
         data=json.dumps(
             {

--- a/Source/Garox_2B00.cpp
+++ b/Source/Garox_2B00.cpp
@@ -1113,7 +1113,7 @@ void Garox_1E34_L::sub_5D33A0()
         ;
     }
     pBrief->field_C = field_6F8_prev_brief;
-    field_6F8_prev_brief->field_8 = 0;
+    field_6F8_prev_brief->field_8_is_brief_onscreen = false;
     field_6F8_prev_brief = field_6F8_prev_brief->field_C;
     pBrief->field_C->field_C = 0;
 }

--- a/Source/Garox_2B00.cpp
+++ b/Source/Garox_2B00.cpp
@@ -1142,10 +1142,10 @@ char_type Garox_1E34_L::sub_5D3680(s16 a1)
 MATCH_FUNC(0x5d39d0)
 void Garox_1E34_L::sub_5D39D0()
 {
-    field_510 = Garox_1E34_L::sub_5D3470();
-    field_504 = field_510 * gGarox_2B00_706620->field_13C4_text_speed;
+    field_510_time_to_show = Garox_1E34_L::sub_5D3470();
+    field_504_tick_timer = field_510_time_to_show * gGarox_2B00_706620->field_13C4_text_speed;
     field_50C = 0;
-    field_514 = 0;
+    field_514_upward_timer = 0;
     field_6F8_prev_brief->field_10 = 0;
 }
 
@@ -1206,11 +1206,11 @@ Garox_1E34_L::Garox_1E34_L()
     field_6FC_p_start_q = &field_518_ary_19_start_q;
 
     field_50C = 0;
-    field_510 = 0;
-    field_514 = 0;
+    field_510_time_to_show = 0;
+    field_514_upward_timer = 0;
     field_6F8_prev_brief = 0;
     field_700 = 0;
-    field_504 = 0;
+    field_504_tick_timer = 0;
 
     for (s32 i = 0; i < 19; i++)
     {

--- a/Source/Garox_2B00.cpp
+++ b/Source/Garox_2B00.cpp
@@ -1113,7 +1113,7 @@ void Garox_1E34_L::sub_5D33A0()
         ;
     }
     pBrief->field_C = field_6F8_prev_brief;
-    field_6F8_prev_brief->field_8_is_brief_onscreen = false;
+    field_6F8_prev_brief->field_8_brief_priority = 0;
     field_6F8_prev_brief = field_6F8_prev_brief->field_C;
     pBrief->field_C->field_C = 0;
 }

--- a/Source/Garox_2B00.hpp
+++ b/Source/Garox_2B00.hpp
@@ -275,7 +275,7 @@ class Garox_18
   public:
     Garox_18** field_0; // prob wrong type
     s32 field_4;
-    s32 field_8_is_brief_onscreen;
+    s32 field_8_brief_priority;
     Garox_18* field_C;  // prob wrong type
     u8 field_10;
     u8 field_11;

--- a/Source/Garox_2B00.hpp
+++ b/Source/Garox_2B00.hpp
@@ -275,7 +275,7 @@ class Garox_18
   public:
     Garox_18** field_0; // prob wrong type
     s32 field_4;
-    s32 field_8;
+    s32 field_8_is_brief_onscreen;
     Garox_18* field_C;  // prob wrong type
     u8 field_10;
     u8 field_11;

--- a/Source/Garox_2B00.hpp
+++ b/Source/Garox_2B00.hpp
@@ -445,13 +445,13 @@ class Garox_1E34_L  // size 0x704
 
     wchar_t field_0_str[640];
     s16 field_500;
-    s16 field_502;
-    s16 field_504;
+    s16 field_502_face_idx;
+    s16 field_504_tick_timer;
     s16 field_506;
-    s32 field_508;
+    s32 field_508_num_lines;
     s32 field_50C;
-    s32 field_510;
-    s32 field_514;
+    s32 field_510_time_to_show;
+    s32 field_514_upward_timer;
     Garox_18* field_518_ary_19_start_q;
     s32 field_51C;
     s32 field_520;

--- a/Source/ImGuiDebug.cpp
+++ b/Source/ImGuiDebug.cpp
@@ -564,13 +564,13 @@ void CC ImGuiDebugDraw()
                 if (pGarox_1E34_L)
                 {
                     ImGui::Value("field_500", pGarox_1E34_L->field_500);
-                    ImGui::InputS16("field_500_face_sprite_idx", &pGarox_1E34_L->field_502, 1, 1);
-                    ImGui::Value("field_504_tick_timer", pGarox_1E34_L->field_504);
+                    ImGui::InputS16("field_502_face_idx", &pGarox_1E34_L->field_502_face_idx, 1, 1);
+                    ImGui::Value("field_504_tick_timer", pGarox_1E34_L->field_504_tick_timer);
                     ImGui::Value("field_506", pGarox_1E34_L->field_506);
-                    ImGui::Value("field_508_num_lines", pGarox_1E34_L->field_508);
+                    ImGui::Value("field_508_num_lines", pGarox_1E34_L->field_508_num_lines);
                     ImGui::Value("field_50C", pGarox_1E34_L->field_50C);
-                    ImGui::Value("field_510_time_to_show", pGarox_1E34_L->field_510);
-                    ImGui::Value("field_514_upward_timer", pGarox_1E34_L->field_514);
+                    ImGui::Value("field_510_time_to_show", pGarox_1E34_L->field_510_time_to_show);
+                    ImGui::Value("field_514_upward_timer", pGarox_1E34_L->field_514_upward_timer);
                     ImGui::Value("field_51C", pGarox_1E34_L->field_51C);
                     ImGui::Value("field_6EC", pGarox_1E34_L->field_6EC);
                     ImGui::Value("field_6F0", pGarox_1E34_L->field_6F0);

--- a/Source/ImGuiDebug.cpp
+++ b/Source/ImGuiDebug.cpp
@@ -564,7 +564,7 @@ void CC ImGuiDebugDraw()
                 if (pGarox_1E34_L)
                 {
                     ImGui::Value("field_500", pGarox_1E34_L->field_500);
-                    ImGui::Value("field_500_face_sprite_idx", pGarox_1E34_L->field_502);
+                    ImGui::InputS16("field_500_face_sprite_idx", &pGarox_1E34_L->field_502, 1, 1);
                     ImGui::Value("field_504_tick_timer", pGarox_1E34_L->field_504);
                     ImGui::Value("field_506", pGarox_1E34_L->field_506);
                     ImGui::Value("field_508_num_lines", pGarox_1E34_L->field_508);

--- a/Source/Network_20324.cpp
+++ b/Source/Network_20324.cpp
@@ -5,8 +5,11 @@
 EXPORT_VAR UINT_PTR gTimerId_6F8A18;
 GLOBAL(gTimerId_6F8A18, 0x6F8A18);
 
+EXPORT_VAR char_type Dest_6F88A4[256];
+GLOBAL(Dest_6F88A4, 0x6F88A4);
+
 STUB_FUNC(0x519960)
-u16 Network_20324::sub_519960(u8* a1, u16* a2)
+u16 __stdcall sub_519960(char_type* a1, wchar_t* a2)
 {
     NOT_IMPLEMENTED;
     return 0;
@@ -19,11 +22,20 @@ char_type Network_20324::sub_5199B0(wchar_t* a1, char_type* a2)
     return 0;
 }
 
-STUB_FUNC(0x519a00)
-char_type* Network_20324::GetString_519A00(const char_type* Key)
+MATCH_FUNC(0x519a00)
+char_type* __stdcall GetString_519A00(const char_type* pKey)
 {
-    NOT_IMPLEMENTED;
-    return 0;
+    wchar_t* pText = gtext_0x14_6F87F0->Find_5B5F90(pKey);
+
+    if (gtext_0x14_6F87F0->field_10_lang_code == 'j')
+    {
+        sub_519960(Dest_6F88A4, pText);
+    }
+    else
+    {
+        wcstombs(Dest_6F88A4, pText, 256u);
+    }
+    return Dest_6F88A4;
 }
 
 MATCH_FUNC(0x519a50)

--- a/Source/Network_20324.hpp
+++ b/Source/Network_20324.hpp
@@ -3,12 +3,15 @@
 #include "Function.hpp"
 #include <windows.h>
 
+EXPORT char_type* __stdcall GetString_519A00(const char_type* Key);
+EXPORT u16 __stdcall sub_519960(char_type* a1, u16* a2);
+
 class Network_20324
 {
   public:
-    EXPORT u16 sub_519960(u8* a1, u16* a2);
+    //EXPORT u16 sub_519960(u8* a1, u16* a2);
     EXPORT static char_type sub_5199B0(wchar_t* a1, char_type* a2);
-    EXPORT char_type* GetString_519A00(const char_type* Key);
+    //EXPORT char_type* GetString_519A00(const char_type* Key);
     EXPORT static void GetString_519A50(wchar_t* Dest, char_type* Source, size_t MaxCount);
     EXPORT Network_20324();
     EXPORT virtual ~Network_20324();

--- a/Source/Ped.hpp
+++ b/Source/Ped.hpp
@@ -380,6 +380,11 @@ class Ped
         return field_16C_car;
     }
 
+    s32 get_id() const
+    {
+        return field_200_id;
+    }
+
     // TODO: to use this inline we need to fix a circular dependency issue
     inline s32 get_car_model();
 

--- a/Source/Zheal_D9C.cpp
+++ b/Source/Zheal_D9C.cpp
@@ -302,7 +302,7 @@ infallible_turing* Crane_15C::sub_4803B0(Fix16 x_pos, Fix16 y_pos, char_type a4)
     field_90_hook_radius = dword_679E58;
     field_84_hook_depth = dword_679E70;
     field_88 = dword_679E70;
-    field_A0_hook_angle = dword_679E70;
+    field_A0_hook_axial_angle = dword_679E70;
     field_A4 = dword_679E70;
     field_AC_crane_angle_target = field_8C_crane_angle;
     field_B0_hook_radius_target = field_90_hook_radius;

--- a/Source/Zheal_D9C.hpp
+++ b/Source/Zheal_D9C.hpp
@@ -85,7 +85,7 @@ class Crane_15C
     Fix16 field_94;
     Fix16 field_98;
     Fix16 field_9C;
-    Fix16 field_A0_hook_angle;  // The angle in its own rotation axis, e.g. the angle of the lifted car
+    Fix16 field_A0_hook_axial_angle;  // The angle in its own rotation axis, e.g. the angle of the lifted car
     Fix16 field_A4;
     Fix16 field_A8;
     Fix16 field_AC_crane_angle_target;  // the crane will rotate until match this angle

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3442,10 +3442,20 @@ void miss2_0x11C::sub_50E9A0()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50e9e0)
-void miss2_0x11C::sub_50E9E0()
+MATCH_FUNC(0x50e9e0)
+void miss2_0x11C::sub_50E9E0() //  SCRCMD_CHECK_HEADS
 {
-    NOT_IMPLEMENTED;
+    SCR_CHECK_HEADS_GREATER* pCmd = (SCR_CHECK_HEADS_GREATER*)gBasePtr_6F8070;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+    if (pPointer->field_8_char->get_wanted_star_count_46EF00() > pCmd->field_A_wanted_level)
+    {
+        field_8 = true;
+    }
+    else
+    {
+        field_8 = false;
+    }
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50ea40)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3478,10 +3478,12 @@ void miss2_0x11C::sub_50ED40()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50ed80)
-void miss2_0x11C::sub_50ED80()
+MATCH_FUNC(0x50ed80)
+void miss2_0x11C::sub_50ED80() //  SCRCMD_CREATE_SOUND
 {
-    NOT_IMPLEMENTED;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+    miss2_0x11C::SCRCMD_SOUND_DECSET_505340((SCR_SOUND_DECSET*)gBasePtr_6F8070, (SCR_POINTER*)pPointer);
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50edc0)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3460,10 +3460,47 @@ void miss2_0x11C::sub_50EB00()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50ebd0)
-void miss2_0x11C::sub_50EBD0()
+MATCH_FUNC(0x50ebd0)
+void miss2_0x11C::sub_50EBD0() //  SCRCMD_WEAP_HIT_CAR
 {
-    NOT_IMPLEMENTED;
+    SCR_WEAPON_HIT_CAR* pCmd = (SCR_WEAPON_HIT_CAR*)gBasePtr_6F8070;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+
+    if (!pCmd->field_A_status)
+    {
+        char v5;
+        if (gBasePtr_6F8070->field_2_type == SCRCMD_WEAP_HIT_CAR)
+        {
+            v5 = gfrosty_pasteur_6F8060->sub_512AF0(pPointer->field_8_car->field_6C_maybe_id, pCmd->field_C_weapon, 0);
+        }
+        else
+        {
+            v5 = gfrosty_pasteur_6F8060->sub_512AF0(pPointer->field_8_car->field_6C_maybe_id, 23, 0);
+        }
+        if (v5 && gfrosty_pasteur_6F8060->sub_512C70(pPointer->field_8_car->field_6C_maybe_id, pCmd->field_C_weapon, 0))
+        {
+            field_8 = true;
+            pCmd->field_A_status = 0;
+        }
+        else
+        {
+            field_8 = false;
+            pCmd->field_A_status = 1;
+        }
+    }
+    else
+    {
+        if (gfrosty_pasteur_6F8060->sub_512C70(pPointer->field_8_car->field_6C_maybe_id, pCmd->field_C_weapon, 0))
+        {
+            field_8 = true;
+            pCmd->field_A_status = 0;
+        }
+        else
+        {
+            field_8 = false;
+        }
+    }
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 // TODO: https://decomp.me/scratch/NMvtk trying to match this using CompilerBitField32 instead of BitSet32

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3448,10 +3448,45 @@ void miss2_0x11C::sub_50E9E0()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50ea40)
-void miss2_0x11C::sub_50EA40()
+MATCH_FUNC(0x50ea40)
+void miss2_0x11C::sub_50EA40() //  SCRCMD_FINISH_LEVEL
 {
-    NOT_IMPLEMENTED;
+    SCR_FINISH_LEVEL* pCmd = (SCR_FINISH_LEVEL*)gBasePtr_6F8070;
+    char bonus_type;
+    switch (pCmd->field_A_bonus_type)
+    {
+        case SCR_BONUSES::NO_BONUS:
+            bonus_type = 0;
+            break;
+        case SCR_BONUSES::BONUS_1:
+            bonus_type = 1;
+            break;
+        case SCR_BONUSES::BONUS_2:
+            bonus_type = 2;
+            break;
+        case SCR_BONUSES::BONUS_3:
+            bonus_type = 3;
+            break;
+        default:
+            break;
+    }
+
+    u32* num_passed_flag = gfrosty_pasteur_6F8060->field_328_passed_flag;
+    if (num_passed_flag != NULL 
+        && gfrosty_pasteur_6F8060->field_314_total_missions == *num_passed_flag)
+    {
+        bonus_type = 2;
+    }
+    if (bonus_type)
+    {
+        gGame_0x40_67E008->sub_4B8BD0(0, 4, bonus_type);
+    }
+    else
+    {
+        gGame_0x40_67E008->sub_4B8C00(0, 4);
+    }
+
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50eb00)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3466,10 +3466,22 @@ void miss2_0x11C::sub_50EBD0()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50ece0)
-void miss2_0x11C::sub_50ECE0()
+// TODO: https://decomp.me/scratch/NMvtk trying to match this using CompilerBitField32 instead of BitSet32
+MATCH_FUNC(0x50ece0)
+void miss2_0x11C::sub_50ECE0() //  SCRCMD_IS_CHAR_ON_FIRE
 {
-    NOT_IMPLEMENTED;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+    BitSet32 flag = pPointer->field_8_char->field_21C;
+
+    if (flag.check_bit(24))
+    {
+        field_8 = true;
+    }
+    else
+    {
+        field_8 = false;
+    }
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50ed40)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3454,16 +3454,38 @@ void miss2_0x11C::sub_50EA40()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50eb00)
-void miss2_0x11C::sub_50EB00()
+MATCH_FUNC(0x50eb00)
+void miss2_0x11C::sub_50EB00() //  SCRCMD_CHECK_WEAPONHIT
 {
-    NOT_IMPLEMENTED;
+    SCR_CHECK_WEAPONHIT* pCmd = (SCR_CHECK_WEAPONHIT*)gBasePtr_6F8070;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+
+    if (!pCmd->field_A_status)
+    {
+        gfrosty_pasteur_6F8060->sub_512AF0(pPointer->field_8_char->get_id(), pCmd->field_C_weapon, 1);
+        field_8 = false;
+        pCmd->field_A_status = 1;
+    }
+    else
+    {
+        if (gfrosty_pasteur_6F8060->sub_512C70(pPointer->field_8_char->get_id(), pCmd->field_C_weapon, 1))
+        {
+            field_8 = true;
+            gfrosty_pasteur_6F8060->sub_512BA0(pPointer->field_8_char->get_id(), 1);
+            pCmd->field_A_status = 0;
+        }
+        else
+        {
+            field_8 = false;
+        }
+    }
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50ebd0)
 void miss2_0x11C::sub_50EBD0() //  SCRCMD_WEAP_HIT_CAR
 {
-    SCR_WEAPON_HIT_CAR* pCmd = (SCR_WEAPON_HIT_CAR*)gBasePtr_6F8070;
+    SCR_CHECK_WEAPONHIT* pCmd = (SCR_CHECK_WEAPONHIT*)gBasePtr_6F8070;
     SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
 
     if (!pCmd->field_A_status)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3472,10 +3472,20 @@ void miss2_0x11C::sub_50ECE0()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50ed40)
-void miss2_0x11C::sub_50ED40()
+MATCH_FUNC(0x50ed40)
+void miss2_0x11C::sub_50ED40() //  SCRCMD_BRIEF_ONSCREEN
 {
-    NOT_IMPLEMENTED;
+    Garox_18* field_6F8_prev_brief = gGarox_2B00_706620->field_DC.field_6F8_prev_brief;
+    if (field_6F8_prev_brief != NULL 
+        && field_6F8_prev_brief->field_8)
+    {
+        field_8 = true;
+    }
+    else
+    {
+        field_8 = false;
+    }
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50ed80)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3447,6 +3447,7 @@ void miss2_0x11C::sub_50E9E0() //  SCRCMD_CHECK_HEADS
 {
     SCR_CHECK_HEADS_GREATER* pCmd = (SCR_CHECK_HEADS_GREATER*)gBasePtr_6F8070;
     SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+
     if (pPointer->field_8_char->get_wanted_star_count_46EF00() > pCmd->field_A_wanted_level)
     {
         field_8 = true;
@@ -3593,7 +3594,7 @@ void miss2_0x11C::sub_50ED40() //  SCRCMD_BRIEF_ONSCREEN
 {
     Garox_18* field_6F8_prev_brief = gGarox_2B00_706620->field_DC.field_6F8_prev_brief;
     if (field_6F8_prev_brief != NULL 
-        && field_6F8_prev_brief->field_8_is_brief_onscreen)
+        && field_6F8_prev_brief->field_8_brief_priority != 0)
     {
         field_8 = true;
     }

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3610,7 +3610,7 @@ void miss2_0x11C::SCRCMD_SUPPRESS_MODEL_50F220()
 }
 
 MATCH_FUNC(0x50f270)
-void miss2_0x11C::sub_50F270()
+void miss2_0x11C::sub_50F270() // WARP_FROM_CAR_TO_POINT
 {
     SCR_WARP_FROM_CAR* pCmd = (SCR_WARP_FROM_CAR*)gBasePtr_6F8070;
     SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
@@ -3733,8 +3733,8 @@ void miss2_0x11C::sub_50F5E0()
 MATCH_FUNC(0x50f770)
 void miss2_0x11C::SCRCMD_MAKE_MUGGERS_50F770()
 {
-    SCR_TWO_PARAMS* pCmd = (SCR_TWO_PARAMS*)gBasePtr_6F8070;
-    if ((u8)pCmd->field_A_unsigned_2 == 1)
+    SCR_MAKE_ALL_MUGGERS* pCmd = (SCR_MAKE_ALL_MUGGERS*)gBasePtr_6F8070;
+    if (pCmd->field_A_status == true)
     {
         gChar_C_6787BC->field_7_make_all_muggers = true;
     }

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3436,10 +3436,12 @@ void miss2_0x11C::sub_50E900()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50e9a0)
+MATCH_FUNC(0x50e9a0)
 void miss2_0x11C::sub_50E9A0()
 {
-    NOT_IMPLEMENTED;
+    gGarox_2B00_706620->field_DC.sub_5D4890(1); // clear lowest brief priority
+    gGarox_2B00_706620->field_DC.sub_5D4890(3); // clear highest brief priority
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50e9e0)

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3477,7 +3477,7 @@ void miss2_0x11C::sub_50ED40() //  SCRCMD_BRIEF_ONSCREEN
 {
     Garox_18* field_6F8_prev_brief = gGarox_2B00_706620->field_DC.field_6F8_prev_brief;
     if (field_6F8_prev_brief != NULL 
-        && field_6F8_prev_brief->field_8)
+        && field_6F8_prev_brief->field_8_is_brief_onscreen)
     {
         field_8 = true;
     }

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3733,8 +3733,8 @@ void miss2_0x11C::sub_50F5E0()
 MATCH_FUNC(0x50f770)
 void miss2_0x11C::SCRCMD_MAKE_MUGGERS_50F770()
 {
-    SCR_MAKE_ALL_MUGGERS* pCmd = (SCR_MAKE_ALL_MUGGERS*)gBasePtr_6F8070;
-    if (pCmd->field_A_status == true)
+    SCR_SET_STATE* pCmd = (SCR_SET_STATE*)gBasePtr_6F8070;
+    if (pCmd->field_A_status == 1)
     {
         gChar_C_6787BC->field_7_make_all_muggers = true;
     }
@@ -3766,8 +3766,8 @@ void miss2_0x11C::SCRCMD_IS_BUS_FULL_50F940()
 MATCH_FUNC(0x50f9b0)
 void miss2_0x11C::SCRCMD_NO_CHARS_OFF_BUS_50F9B0()
 {
-    SCR_TWO_PARAMS* pCmd = (SCR_TWO_PARAMS*)gBasePtr_6F8070;
-    if ((u8)pCmd->field_A_unsigned_2 == 1)
+    SCR_SET_STATE* pCmd = (SCR_SET_STATE*)gBasePtr_6F8070;
+    if (pCmd->field_A_status == 1)
     {
         gSero_181C_6FF1D4->field_1818_stop_getting_off_bus = true;
     }

--- a/Source/miss2_0x11C.cpp
+++ b/Source/miss2_0x11C.cpp
@@ -3373,10 +3373,14 @@ void miss2_0x11C::SCRCMD_CHECK_CAR_SPEED_50E360()
     NOT_IMPLEMENTED;
 }
 
-STUB_FUNC(0x50e460)
-void miss2_0x11C::sub_50E460()
+MATCH_FUNC(0x50e460)
+void miss2_0x11C::sub_50E460() //  SCRCMD_SET_CAR_GRAPHIC
 {
-    NOT_IMPLEMENTED;
+    SCR_SET_CAR_GRAPHIC* pCmd = (SCR_SET_CAR_GRAPHIC*)gBasePtr_6F8070;
+    SCR_POINTER* pPointer = (SCR_POINTER*)gfrosty_pasteur_6F8060->GetBasePointer_512770(gBasePtr_6F8070[1].field_0_cmd_this);
+
+    pPointer->field_8_car->sub_43CDF0(pCmd->field_C_number); // set the number on the top of the car
+    miss2_0x11C::Next_503620(gBasePtr_6F8070);
 }
 
 MATCH_FUNC(0x50e4a0)

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -471,6 +471,13 @@ struct SCR_SET_STATE : SCR_CMD_HEADER
     u8 field_A_status;
 };
 
+struct SCR_WEAPON_HIT_CAR : SCR_CMD_HEADER
+{
+    u16 field_8_car_idx;
+    u16 field_A_status;
+    u16 field_C_weapon;
+};
+
 namespace SCR_DOOR_OPENTYPES
 {
 enum

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -465,7 +465,7 @@ struct SCR_STORE_BONUS_COUNT : SCR_CMD_HEADER
     u16 field_A_counter_idx;
 };
 
-struct SCR_MAKE_ALL_MUGGERS : SCR_CMD_HEADER
+struct SCR_SET_STATE : SCR_CMD_HEADER
 {
     u16 field_8_unk;
     u8 field_A_status;

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -494,6 +494,13 @@ struct SCR_CHECK_HEADS_GREATER : SCR_CMD_HEADER
     s16 field_A_wanted_level;
 };
 
+struct SCR_SET_CAR_GRAPHIC : SCR_CMD_HEADER
+{
+    u16 field_8_car_idx;
+    u16 field_A_unk;
+    u16 field_C_number;
+};
+
 namespace SCR_DOOR_OPENTYPES
 {
 enum

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -488,6 +488,12 @@ struct SCR_FINISH_LEVEL : SCR_CMD_HEADER
     s16 field_A_bonus_type;
 };
 
+struct SCR_CHECK_HEADS_GREATER : SCR_CMD_HEADER
+{
+    u16 field_8_ped_idx;
+    s16 field_A_wanted_level;
+};
+
 namespace SCR_DOOR_OPENTYPES
 {
 enum

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -465,6 +465,12 @@ struct SCR_STORE_BONUS_COUNT : SCR_CMD_HEADER
     u16 field_A_counter_idx;
 };
 
+struct SCR_MAKE_ALL_MUGGERS : SCR_CMD_HEADER
+{
+    u16 field_8_unk;
+    u8 field_A_status;
+};
+
 namespace SCR_DOOR_OPENTYPES
 {
 enum

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -471,9 +471,13 @@ struct SCR_SET_STATE : SCR_CMD_HEADER
     u8 field_A_status;
 };
 
-struct SCR_WEAPON_HIT_CAR : SCR_CMD_HEADER
+struct SCR_CHECK_WEAPONHIT : SCR_CMD_HEADER
 {
-    u16 field_8_car_idx;
+    union
+    {
+        u16 field_8_car_idx;
+        u16 field_8_ped_idx;
+    };
     u16 field_A_status;
     u16 field_C_weapon;
 };

--- a/Source/miss2_0x11C.hpp
+++ b/Source/miss2_0x11C.hpp
@@ -482,6 +482,12 @@ struct SCR_CHECK_WEAPONHIT : SCR_CMD_HEADER
     u16 field_C_weapon;
 };
 
+struct SCR_FINISH_LEVEL : SCR_CMD_HEADER
+{
+    u16 field_8_unk;
+    s16 field_A_bonus_type;
+};
+
 namespace SCR_DOOR_OPENTYPES
 {
 enum
@@ -508,6 +514,17 @@ enum
 };
 //static_assert(sizeof(SCR_DOOR_CLOSETYPES) == 1)
 } // namespace SCR_DOOR_CLOSETYPES
+
+namespace SCR_BONUSES
+{
+enum
+{
+    NO_BONUS = 0,
+    BONUS_1 = 1,
+    BONUS_2 = 2,
+    BONUS_3 = 3,
+};
+}
 
 EXPORT_VAR extern Fix16 dword_6F77C0;
 EXPORT_VAR extern Fix16 dword_6F77C4;


### PR DESCRIPTION
match miss2_0x11C::sub_50ED80
match miss2_0x11C::sub_50ED40
match miss2_0x11C::sub_50ECE0
match miss2_0x11C::sub_50EBD0
match miss2_0x11C::sub_50EB00
match miss2_0x11C::sub_50EA40
match miss2_0x11C::sub_50E9E0
match miss2_0x11C::sub_50E9A0
match miss2_0x11C::sub_50E460
match Network_20324::GetString_519A00

# Field renames:

Garox_1E34_L:
field_502 -> field_502_face_idx
field_504 -> field_504_tick_timer
field_508 -> field_508_num_lines
field_510 -> field_510_time_to_show
field_514 -> field_514_upward_timer

Garox_18:
field_8 -> field_8_brief_priority
