### PR TITLE
CarAI renames & improvements

### DIFF
--- a/Source/CarAI_78.cpp
+++ b/Source/CarAI_78.cpp
@@ -14,16 +14,16 @@
 
 DEFINE_GLOBAL(Ang16, word_677CE8, 0x677CE8);
 DEFINE_GLOBAL(Fix16, dword_677B90, 0x677B90);
-DEFINE_GLOBAL(Fix16, dword_677C30, 0x677C30);
-DEFINE_GLOBAL(Fix16, dword_677C38, 0x677C38);
-DEFINE_GLOBAL(Fix16, dword_677C48, 0x677C48);
+DEFINE_GLOBAL(Fix16, gCurrCarAI_ypos_677C30, 0x677C30);
+DEFINE_GLOBAL(Fix16, gCurrCarAI_xpos_677C38, 0x677C38);
+DEFINE_GLOBAL(Fix16, gCurrCarAI_zpos_677C48, 0x677C48);
 DEFINE_GLOBAL(Fix16, dword_6779F8, 0x6779F8);
 
 DEFINE_GLOBAL_INIT(Fix16, dword_677BA0, Fix16(0x10000, 0), 0x677BA0);
 DEFINE_GLOBAL_INIT(Fix16, dword_677B5C, Fix16(0x147, 0), 0x677B5C);
 DEFINE_GLOBAL_INIT(Fix16, dword_677AC4, dword_677B5C, 0x677AC4);
 
-DEFINE_GLOBAL_INIT(Fix16, dword_677B94, Fix16(0x4000, 0), 0x677B94);
+DEFINE_GLOBAL_INIT(Fix16, gF16fOne_677B94, Fix16(1), 0x677B94); // Value = 1.0 in float
 DEFINE_GLOBAL_INIT(Fix16, dword_6779B8, Fix16(0x666, 0), 0x6779B8);
 DEFINE_GLOBAL_INIT(Fix16, dword_677B50, Fix16(163, 0), 0x677B50);
 DEFINE_GLOBAL_INIT(Fix16, dword_677CB4, dword_6779B8, 0x677CB4);
@@ -32,7 +32,7 @@ DEFINE_GLOBAL_INIT(Fix16, dword_6779A4, dword_677B50, 0x6779A4);
 DEFINE_GLOBAL_INIT(Fix16, dword_6779D4, Fix16(0x2CCC, 0), 0x6779D4);
 DEFINE_GLOBAL(CarAI_78_Pool*, gCarAI_78_Pool_677CF8, 0x677CF8);
 
-DEFINE_GLOBAL(Fix16, dword_677B00, 0x677B00);
+DEFINE_GLOBAL(Fix16, gCurrCarAI_Velocity_677B00, 0x677B00);
 DEFINE_GLOBAL_INIT(Fix16, dword_677B60, Fix16(0x333, 0), 0x677B60);
 
 DEFINE_GLOBAL(u8, byte_677BBC, 0x677BBC);
@@ -73,13 +73,13 @@ DEFINE_GLOBAL_INIT(Fix16, dword_677B98, Fix16(0x8000, 0), 0x677B98);
 DEFINE_GLOBAL_INIT(Fix16, dword_6779BC, Fix16(0x1000, 0), 0x6779BC);
 DEFINE_GLOBAL_INIT(Fix16, dword_677CBC, Fix16(0x800, 0), 0x677CBC);
 
-DEFINE_GLOBAL_INIT(Ang16, word_677ADE, Ang16(0x02D0), 0x677ADE);
-DEFINE_GLOBAL_INIT(Ang16, dword_6779E4, Ang16(0x0168), 0x6779E4);
+DEFINE_GLOBAL_INIT(Ang16, word_677ADE, Ang16(720), 0x677ADE);
+DEFINE_GLOBAL_INIT(Ang16, dword_6779E4, Ang16(360), 0x6779E4);
 DEFINE_GLOBAL_INIT(Ang16, dword_677A2E, Ang16(0x30), 0x677A2E);
 DEFINE_GLOBAL_INIT(Ang16, word_677CE2, Ang16(0x10), 0x677CE2);
 
 DEFINE_GLOBAL_INIT(Fix16, dword_677C84, Fix16(0x18F60, 0), 0x677C84);
-DEFINE_GLOBAL_INIT(Ang16, word_677B08, Ang16(0x0438), 0x677B08);
+DEFINE_GLOBAL_INIT(Ang16, word_677B08, Ang16(1080), 0x677B08);
 DEFINE_GLOBAL_INIT(Fix16, dword_677BA4, Fix16(0x14000, 0), 0x677BA4);
 DEFINE_GLOBAL_INIT(Fix16, dword_677CA0, Fix16(0x14000, 0), 0x677CA0);
 DEFINE_GLOBAL_INIT(Fix16, dword_677B78, Fix16(0x5C2, 0), 0x677B78);
@@ -88,7 +88,7 @@ DEFINE_GLOBAL_INIT(Fix16, dword_677B70, Fix16(0x3D7, 0), 0x677B70);
 DEFINE_GLOBAL_INIT(Fix16, dword_677950, Fix16(0x3FC000, 0), 0x677950);
 DEFINE_GLOBAL_INIT(Fix16, dword_6779D8, Fix16(0x3333, 0), 0x6779D8);
 DEFINE_GLOBAL_INIT(Fix16, dword_677B64, Fix16(0x28F, 0), 0x677B64);
-DEFINE_GLOBAL_INIT(Ang16, word_677A38, Ang16(0x00B4), 0x677A38);
+DEFINE_GLOBAL_INIT(Ang16, word_677A38, Ang16(180), 0x677A38);
 
 EXTERN_GLOBAL(u16, word_677CFC);
 EXTERN_GLOBAL(u8, byte_6771DC);
@@ -249,7 +249,7 @@ void CarAI_78::sub_447970()
     if (field_28_junc_idx > 0)
     {
         u16 v9 = gRouteFinder_6FFDC8->field_2218[field_28_junc_idx].field_0[this->field_56];
-        if (!v9 || (u8)v7 == (u16)(dword_677C38.ToInt()) && (u8)v8 == (u16)(dword_677C30.ToInt()))
+        if (!v9 || (u8)v7 == (u16)(gCurrCarAI_xpos_677C38.ToInt()) && (u8)v8 == (u16)(gCurrCarAI_ypos_677C30.ToInt()))
         {
             gRouteFinder_6FFDC8->CancelRoute_589930(field_28_junc_idx);
             Car_BC* v17 = this->field_0;
@@ -269,18 +269,18 @@ void CarAI_78::sub_447970()
                                                                         v19,
                                                                         gRouteFinder_6FFDC8->field_2218[0].field_0[v11],
                                                                         gRouteFinder_6FFDC8->field_2218[0].field_0[v11 + 1]) &&
-                    v18 == (u16)(field_0->field_50_car_sprite->field_1C_zpos - dword_677B94).ToInt())
+                    v18 == (u16)(field_0->field_50_car_sprite->field_1C_zpos - gF16fOne_677B94).ToInt())
                 {
                     switch (
                         Junction_58A0B0->sub_5885C0(gRouteFinder_6FFDC8->field_2218[this->field_28_junc_idx].field_0[this->field_56 + 1]))
                     {
                         case 1:
-                            if (v19 >= (u8)(dword_677C30.ToInt()))
+                            if (v19 >= (u8)(gCurrCarAI_ypos_677C30.ToInt()))
                             {
                                 goto LABEL_13;
                             }
-                            v12 = (u8)v7 < (u8)(dword_677C38.ToInt());
-                            if ((u8)v7 <= (u8)(dword_677C38.ToInt()))
+                            v12 = (u8)v7 < (u8)(gCurrCarAI_xpos_677C38.ToInt());
+                            if ((u8)v7 <= (u8)(gCurrCarAI_xpos_677C38.ToInt()))
                             {
                                 goto LABEL_16;
                             }
@@ -288,12 +288,12 @@ void CarAI_78::sub_447970()
                             goto LABEL_28;
 
                         case 2:
-                            if (v19 <= (u8)(dword_677C30.ToInt()))
+                            if (v19 <= (u8)(gCurrCarAI_ypos_677C30.ToInt()))
                             {
                                 goto LABEL_13;
                             }
-                            v12 = (u8)v7 < (u8)(dword_677C38.ToInt());
-                            if ((u8)v7 > (u8)(dword_677C38.ToInt()))
+                            v12 = (u8)v7 < (u8)(gCurrCarAI_xpos_677C38.ToInt());
+                            if ((u8)v7 > (u8)(gCurrCarAI_xpos_677C38.ToInt()))
                             {
                                 v13 = this->field_24_flags | 0x40000;
                                 goto LABEL_28;
@@ -306,15 +306,15 @@ void CarAI_78::sub_447970()
                             break;
 
                         case 3:
-                            if ((u8)v7 >= (u8)(dword_677C38.ToInt()))
+                            if ((u8)v7 >= (u8)(gCurrCarAI_xpos_677C38.ToInt()))
                             {
                                 goto LABEL_13;
                             }
-                            if (v19 > (u8)(dword_677C30.ToInt()))
+                            if (v19 > (u8)(gCurrCarAI_ypos_677C30.ToInt()))
                             {
                                 goto LABEL_27;
                             }
-                            if (v19 >= (u8)(dword_677C30.ToInt()))
+                            if (v19 >= (u8)(gCurrCarAI_ypos_677C30.ToInt()))
                             {
                                 break;
                             }
@@ -322,7 +322,7 @@ void CarAI_78::sub_447970()
                             goto LABEL_28;
 
                         case 4:
-                            if ((u8)v7 <= (u8)(dword_677C38.ToInt()))
+                            if ((u8)v7 <= (u8)(gCurrCarAI_xpos_677C38.ToInt()))
                             {
                             LABEL_13:
                                 this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::anticlockwise_1;
@@ -331,9 +331,9 @@ void CarAI_78::sub_447970()
                                 this->field_0->field_60->field_26 = 1;
                                 return;
                             }
-                            if (v19 <= (u8)(dword_677C30.ToInt()))
+                            if (v19 <= (u8)(gCurrCarAI_ypos_677C30.ToInt()))
                             {
-                                if (v19 >= (u8)(dword_677C30.ToInt()))
+                                if (v19 >= (u8)(gCurrCarAI_ypos_677C30.ToInt()))
                                 {
                                     break;
                                 }
@@ -354,9 +354,9 @@ void CarAI_78::sub_447970()
                 }
             }
 
-            s32 v14 = dword_677C30.ToInt();
-            if ((s16)(dword_677C38.ToInt()) < Junction_58A0B0->field_C_min_x ||
-                (s16)(dword_677C38.ToInt()) > Junction_58A0B0->field_E_max_x || (s16)v14 < Junction_58A0B0->field_D_min_y ||
+            s32 v14 = gCurrCarAI_ypos_677C30.ToInt();
+            if ((s16)(gCurrCarAI_xpos_677C38.ToInt()) < Junction_58A0B0->field_C_min_x ||
+                (s16)(gCurrCarAI_xpos_677C38.ToInt()) > Junction_58A0B0->field_E_max_x || (s16)v14 < Junction_58A0B0->field_D_min_y ||
                 (s16)v14 > Junction_58A0B0->field_F_max_y)
             {
                 if ((field_24_flags & 2) != 0)
@@ -377,9 +377,9 @@ void CarAI_78::sub_447970()
 MATCH_FUNC(0x447ca0)
 bool CarAI_78::GoToBlock_447CA0(u8 x, u8 y, u8 z, s32 maybe_direction)
 {
-    field_28_junc_idx = gRouteFinder_6FFDC8->StartRoute_58A190(dword_677C38.ToInt(),
-                                                               dword_677C30.ToInt(),
-                                                               (dword_677C48 - dword_677B94).ToInt(),
+    field_28_junc_idx = gRouteFinder_6FFDC8->StartRoute_58A190(gCurrCarAI_xpos_677C38.ToInt(),
+                                                               gCurrCarAI_ypos_677C30.ToInt(),
+                                                               (gCurrCarAI_zpos_677C48 - gF16fOne_677B94).ToInt(),
                                                                x,
                                                                y,
                                                                z,
@@ -695,13 +695,13 @@ void CarAI_78::sub_4482C0()
         u8 v5;
         if ((this->field_24_flags & 0x20000) != 0)
         {
-            Fix16 v7 = dword_677C48;
-            Fix16 v8 = dword_677C30;
+            Fix16 v7 = gCurrCarAI_zpos_677C48;
+            Fix16 v8 = gCurrCarAI_ypos_677C30;
 
-            field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, v8, v7);
+            field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, v8, v7);
 
-            Fix16 v14 = (dword_677B94 * Ang16::cosine_40F520(this->field_10_angle)) + field_0->field_50_car_sprite->field_14_xy.y;
-            Fix16 v15 = (dword_677B94 * Ang16::sine_40F500(this->field_10_angle)) + field_0->field_50_car_sprite->field_14_xy.x;
+            Fix16 v14 = (gF16fOne_677B94 * Ang16::cosine_40F520(this->field_10_angle)) + field_0->field_50_car_sprite->field_14_xy.y;
+            Fix16 v15 = (gF16fOne_677B94 * Ang16::sine_40F500(this->field_10_angle)) + field_0->field_50_car_sprite->field_14_xy.x;
 
             field_0->field_50_car_sprite->set_xyz_lazy_420600(v15, v14, field_0->field_50_car_sprite->field_1C_zpos);
 
@@ -774,7 +774,7 @@ void CarAI_78::sub_4482C0()
                     if (v6)
                     {
                         v33 = 6;
-                        v18 -= dword_677B94;
+                        v18 -= gF16fOne_677B94;
                     }
                     else
                     {
@@ -823,7 +823,7 @@ void CarAI_78::sub_4482C0()
             field_0->field_50_car_sprite->set_xyz_lazy_420600(v18, v19, field_0->field_50_car_sprite->field_1C_zpos);
 
             v1->set_ang_lazy_420690(dword_6779E4 + this->field_10_angle);
-            v1->AllocInternal_59F950(dword_677B94, dword_677B94, dword_6779C0);
+            v1->AllocInternal_59F950(gF16fOne_677B94, gF16fOne_677B94, dword_6779C0);
 
             gPurpleDoom_1_679208->FindNearestSpriteOfType_477E60(v1, 0); // rvalue not used ??
             if ((u8)v33)
@@ -845,16 +845,16 @@ void CarAI_78::sub_4482C0()
             switch (this->field_4C_curr_direction)
             {
                 case car_ai_direction::north_1:
-                    v32 -= dword_677B94;
+                    v32 -= gF16fOne_677B94;
                     break;
                 case car_ai_direction::south_2:
-                    v32 += dword_677B94;
+                    v32 += gF16fOne_677B94;
                     break;
                 case car_ai_direction::east_3:
-                    v18 += dword_677B94;
+                    v18 += gF16fOne_677B94;
                     break;
                 case car_ai_direction::west_4:
-                    v18 -= dword_677B94;
+                    v18 -= gF16fOne_677B94;
                     break;
                 default:
                     break;
@@ -966,7 +966,7 @@ void CarAI_78::sub_448770()
         toUse = dword_6779D8;
     }
 
-    if (dword_677B00 < dword_677B64)
+    if (gCurrCarAI_Velocity_677B00 < dword_677B64)
     {
         toUse = dword_6779C0;
     }
@@ -989,14 +989,14 @@ void CarAI_78::sub_448770()
                 {
                     case car_ai_direction::north_1:
                         new_y -= dword_677A84;
-                        new_x -= dword_677B94;
+                        new_x -= gF16fOne_677B94;
                         break;
                     case car_ai_direction::south_2:
-                        new_y += dword_677B94;
+                        new_y += gF16fOne_677B94;
                         new_x += dword_677B98;
                         break;
                     case car_ai_direction::east_3:
-                        new_x += dword_677B94;
+                        new_x += gF16fOne_677B94;
                         new_y += dword_677B98;
                         break;
                     case car_ai_direction::west_4:
@@ -1009,7 +1009,7 @@ void CarAI_78::sub_448770()
 
                 obj_5C_f58->set_xyz_lazy_420600(new_x, new_y, this->field_0->field_50_car_sprite->field_1C_zpos);
                 obj_5C_f58->set_ang_lazy_420690(dword_6779E4 + this->field_10_angle);
-                obj_5C_f58->AllocInternal_59F950(dword_677B94, dword_677A84, dword_6779C0);
+                obj_5C_f58->AllocInternal_59F950(gF16fOne_677B94, dword_677A84, dword_6779C0);
 
                 Sprite* pNearestSpriteOfType = gPurpleDoom_1_679208->FindNearestSpriteOfType_477E60(obj_5C_f58, 0);
                 if (pNearestSpriteOfType)
@@ -1115,10 +1115,10 @@ void CarAI_78::sub_448CE0()
 {
     WIP_IMPLEMENTED;
 
-    Fix16 v1 = dword_677C48;
-    Fix16 v3 = dword_677C30;
+    Fix16 v1 = gCurrCarAI_zpos_677C48;
+    Fix16 v3 = gCurrCarAI_ypos_677C30;
 
-    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+    field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
     this->field_24_flags |= 0x400u;
     gmp_block_info* block_4DFE10 = gMap_0x370_6F6268->get_block_4DFE10(field_0->field_50_car_sprite->field_14_xy.x.ToInt(),
@@ -1998,26 +1998,26 @@ void CarAI_78::sub_44A1F0()
                     {
                         case 0:
                             v28 = this->field_10_angle;
-                            v25 = (gSin_table_667A80[v28.rValue] * dword_677B94);
-                            v40 = (gCos_table_669260[v28.rValue] * dword_677B94);
+                            v25 = (gSin_table_667A80[v28.rValue] * gF16fOne_677B94);
+                            v40 = (gCos_table_669260[v28.rValue] * gF16fOne_677B94);
                             break;
 
                         case 1:
                             v28 = dword_6779E4 + this->field_10_angle;
-                            v25 = (gSin_table_667A80[v28.rValue] * dword_677B94);
-                            v40 = (gCos_table_669260[v28.rValue] * dword_677B94);
+                            v25 = (gSin_table_667A80[v28.rValue] * gF16fOne_677B94);
+                            v40 = (gCos_table_669260[v28.rValue] * gF16fOne_677B94);
                             break;
 
                         case 2:
                             v28 = dword_6779E4 - this->field_10_angle;
-                            v25 = (gSin_table_667A80[v28.rValue] * dword_677B94);
-                            v40 = (gCos_table_669260[v28.rValue] * dword_677B94);
+                            v25 = (gSin_table_667A80[v28.rValue] * gF16fOne_677B94);
+                            v40 = (gCos_table_669260[v28.rValue] * gF16fOne_677B94);
                             break;
 
                         case 3:
                             v28 = word_677ADE + this->field_10_angle;
-                            v25 = (gSin_table_667A80[v28.rValue] * dword_677B94);
-                            v40 = (gCos_table_669260[v28.rValue] * dword_677B94);
+                            v25 = (gSin_table_667A80[v28.rValue] * gF16fOne_677B94);
+                            v40 = (gCos_table_669260[v28.rValue] * gF16fOne_677B94);
                             break;
 
                         default:
@@ -2075,11 +2075,11 @@ void CarAI_78::sub_44AF00()
     if ((this->field_24_flags & 0x100) != 0)
     {
         byte_677A5D = 0;
-        char_type v2 = this->field_0->CountConsecutiveArrowBlocks_4410D0(this->field_10_angle, &v72, dword_677C38, dword_677C30);
-        Fix16 v3 = dword_677C48;
-        Fix16 v4 = dword_677C30;
+        char_type v2 = this->field_0->CountConsecutiveArrowBlocks_4410D0(this->field_10_angle, &v72, gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30);
+        Fix16 v3 = gCurrCarAI_zpos_677C48;
+        Fix16 v4 = gCurrCarAI_ypos_677C30;
 
-        this->field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+        this->field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
         if (v2 == (u8)this->field_2F)
         {
@@ -2587,7 +2587,7 @@ void CarAI_78::sub_44D1D0()
     u8 v111 = 0;
     do
     {
-        Fix16 v112 = (dword_677B94 * (Fix16(v111)));
+        Fix16 v112 = (gF16fOne_677B94 * (Fix16(v111)));
         Fix16 v15 = (gSin_table_667A80[field_10_angle.rValue] * v112);
         Fix16 v16 = (gCos_table_669260[field_10_angle.rValue] * v112);
         Fix16 v17 = v15 + this->field_0->field_50_car_sprite->field_14_xy.x;
@@ -2617,7 +2617,7 @@ void CarAI_78::sub_44D1D0()
         v111 = ++v12;
     } while (v12 < 5u);
 
-    char_type v20 = field_0->CountConsecutiveArrowBlocks_4410D0(field_10_angle, &v109, dword_677C38, dword_677C30);
+    char_type v20 = field_0->CountConsecutiveArrowBlocks_4410D0(field_10_angle, &v109, gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30);
     char_type v110 = v20;
     if (v109 <= 1)
     {
@@ -2637,7 +2637,7 @@ void CarAI_78::sub_44D1D0()
         {
             if (byte_677A94 || dword_677A8C > dword_6779C0 || field_70->field_8_car_bc_ptr->sub_43A240() == dword_677B90)
             {
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
                 switch (this->field_4C_curr_direction)
                 {
@@ -2803,9 +2803,9 @@ LABEL_90:
         v21 = byte_677A94;
     }
 
-    if (dword_677B00 < dword_677B60 || v21)
+    if (gCurrCarAI_Velocity_677B00 < dword_677B60 || v21)
     {
-        field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+        field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
         switch (this->field_4C_curr_direction)
         {
@@ -2976,8 +2976,8 @@ void CarAI_78::sub_44E0C0()
     }
 
     dword_6779F8 = target_z;
-    Fix16 abs_y = Fix16::Abs_436A50(target_y - dword_677C30);
-    Fix16 abs_x = Fix16::Abs_436A50(target_x - dword_677C38);
+    Fix16 abs_y = Fix16::Abs_436A50(target_y - gCurrCarAI_ypos_677C30);
+    Fix16 abs_x = Fix16::Abs_436A50(target_x - gCurrCarAI_xpos_677C38);
     if (Fix16::Max_44E540(abs_x, abs_y) < dword_677BA4 && this->field_0->field_60->field_8_maybe_path_type != 1)
     {
         if (field_28_junc_idx > 0)
@@ -3051,8 +3051,8 @@ void CarAI_78::sub_44E0C0()
         if (!pBlock || (pBlock->field_B_slope_type & 0xFC) == 0 || (pBlock->field_B_slope_type & 0xFCu) >= 0xB4 ||
             (pBlock->field_B_slope_type & 3) == 0)
         {
-            maybe_z = dword_6779F8 - dword_677B94;
-            pBlock = gMap_0x370_6F6268->get_block_4DFE10(dword_6779F0.ToInt(), dword_6779F4.ToInt(), (dword_6779F8 - dword_677B94).ToInt());
+            maybe_z = dword_6779F8 - gF16fOne_677B94;
+            pBlock = gMap_0x370_6F6268->get_block_4DFE10(dword_6779F0.ToInt(), dword_6779F4.ToInt(), (dword_6779F8 - gF16fOne_677B94).ToInt());
         }
         if (pBlock && (u8)gMap_0x370_6F6268->GetArrowDirectionFromBlock_4E5FC0(pBlock, 1))
         {
@@ -3074,9 +3074,9 @@ void CarAI_78::sub_44E0C0()
             if (!pBlock_ || (pBlock_->field_B_slope_type & 0xFC) == 0 || (pBlock_->field_B_slope_type & 0xFCu) >= 0xB4 ||
                 (pBlock_->field_B_slope_type & 3) == 0)
             {
-                maybe_z = dword_6779F8 - dword_677B94;
+                maybe_z = dword_6779F8 - gF16fOne_677B94;
                 pBlock_ =
-                    gMap_0x370_6F6268->get_block_4DFE10(dword_6779F0.ToInt(), dword_6779F4.ToInt(), (dword_6779F8 - dword_677B94).ToInt());
+                    gMap_0x370_6F6268->get_block_4DFE10(dword_6779F0.ToInt(), dword_6779F4.ToInt(), (dword_6779F8 - gF16fOne_677B94).ToInt());
             }
             if (pBlock_)
             {
@@ -3201,26 +3201,26 @@ void CarAI_78::UpdateStateMachine_44E560()
             {
                 if (dword_6779B0)
                 {
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v265 = dword_6779B0->field_50_car_sprite->field_0 - word_677ADE;
 
                     dword_6779F0 += (Ang16::sine_40F500(v265) * dword_677B9C);
                     dword_6779F4 += (Ang16::cosine_40F520(v265) * dword_677B9C);
 
-                    Fix16 v219 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v17 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v219 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v17 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                     v245 = Fix16::Max_44E540(v17, v219);
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 else
                 {
-                    Fix16 v220 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v18 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v220 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v18 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                     v245 = Fix16::Max_44E540(v18, v220);
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 break;
             }
@@ -3229,17 +3229,17 @@ void CarAI_78::UpdateStateMachine_44E560()
             {
                 if (dword_6779B0)
                 {
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v254 = dword_6779B0->field_50_car_sprite->field_0 - word_677ADE;
                     dword_6779F0 += (dword_677B9C * Ang16::sine_40F500(v254));
                     dword_6779F4 += (dword_677B9C * Ang16::cosine_40F520(v254));
 
-                    Fix16 v222 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v29 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v222 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v29 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                     v245 = Fix16::Max_44E540(v29, v222);
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 break;
             }
@@ -3248,7 +3248,7 @@ void CarAI_78::UpdateStateMachine_44E560()
             {
                 if (dword_6779B0)
                 {
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v266 = dword_6779B0->field_50_car_sprite->field_0 - word_677ADE;
                     dword_6779F0 += (dword_677B9C * Ang16::sine_40F500(v266));
@@ -3258,51 +3258,51 @@ void CarAI_78::UpdateStateMachine_44E560()
                     dword_6779F0 += (dword_677A84 * Ang16::sine_40F500(v264));
                     dword_6779F4 += (dword_677A84 * Ang16::cosine_40F520(v264));
 
-                    Fix16 v221 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v24 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v221 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v24 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                     v245 = Fix16::Max_44E540(v24, v221);
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 break;
             }
 
             case 3:
             {
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 Ang16 v253 = dword_6779B0->field_50_car_sprite->field_0 - dword_6779E4;
-                dword_6779F0 += (dword_677B94 * Ang16::sine_40F500(v253));
-                dword_6779F4 += (dword_677B94 * Ang16::cosine_40F520(v253));
+                dword_6779F0 += (gF16fOne_677B94 * Ang16::sine_40F500(v253));
+                dword_6779F4 += (gF16fOne_677B94 * Ang16::cosine_40F520(v253));
 
                 dword_6779F0 += (dword_677A84 * Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0));
                 dword_6779F4 += (dword_677A84 * Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0));
 
-                Fix16 v223 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v36 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v223 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v36 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                 v245 = Fix16::Max_44E540(v36, v223);
 
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
             case 4:
             {
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 Ang16 v240 = dword_6779E4 + dword_6779B0->field_50_car_sprite->field_0;
-                dword_6779F0 += (dword_677B94 * Ang16::sine_40F500(v240));
-                dword_6779F4 += (dword_677B94 * Ang16::cosine_40F520(v240));
+                dword_6779F0 += (gF16fOne_677B94 * Ang16::sine_40F500(v240));
+                dword_6779F4 += (gF16fOne_677B94 * Ang16::cosine_40F520(v240));
 
                 dword_6779F0 += (dword_677A84 * Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0));
                 dword_6779F4 += (dword_677A84 * Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0));
 
-                Fix16 v225 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v50 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v225 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v50 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                 v245 = Fix16::Max_44E540(v50, v225);
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
@@ -3311,55 +3311,55 @@ void CarAI_78::UpdateStateMachine_44E560()
                 Fix16 v42;
                 if (v6 == 1)
                 {
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v244 = dword_6779B0->field_50_car_sprite->field_0 - word_677ADE;
-                    dword_6779F0 += (dword_677B94 * Ang16::sine_40F500(v244));
+                    dword_6779F0 += (gF16fOne_677B94 * Ang16::sine_40F500(v244));
                     v42 = dword_6779F0; // TODO: Check ?
-                    dword_6779F4 += (dword_677B94 * Ang16::cosine_40F520(v244));
+                    dword_6779F4 += (gF16fOne_677B94 * Ang16::cosine_40F520(v244));
                 }
                 else
                 {
                     v42 = dword_6779F0;
                 }
-                Fix16 v224 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v43 = Fix16::Abs_436A50(v42 - dword_677C38);
+                Fix16 v224 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v43 = Fix16::Abs_436A50(v42 - gCurrCarAI_xpos_677C38);
                 v245 = Fix16::Max_44E540(v43, v224);
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
             case 6:
             {
                 MakeAgressiveSirensAndLights_4476F0();
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 Ang16 v260 = dword_6779B0->field_50_car_sprite->field_0 - dword_6779E4;
                 dword_6779F0 += (Ang16::sine_40F500(v260) * dword_677A4C);
                 dword_6779F4 += (Ang16::cosine_40F520(v260) * dword_677A4C);
 
-                Fix16 v226 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v54 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v226 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v54 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
                 v245 = Fix16::Max_44E540(v54, v226);
 
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
             case 7:
             {
                 MakeAgressiveSirensAndLights_4476F0();
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 Ang16 v258 = dword_6779E4 + dword_6779B0->field_50_car_sprite->field_0;
                 dword_6779F0 += (Ang16::sine_40F500(v258) * dword_677A4C);
                 dword_6779F4 += (Ang16::cosine_40F520(v258) * dword_677A4C);
 
-                Fix16 v229 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v70 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v229 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v70 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                 v245 = Fix16::Max_44E540(v70, v229);
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
@@ -3438,22 +3438,22 @@ void CarAI_78::UpdateStateMachine_44E560()
                     }
                     pHam40->field_10 = 1;
 
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
-                    dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94);
-                    dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94);
+                    dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94);
+                    dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94);
 
-                    Fix16 v228 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v66 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v228 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v66 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                     v245 = Fix16::Max_44E540(v66, v228);
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 else
                 {
                     ++pHam40->field_2E;
 
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v262 = dword_6779B0->field_50_car_sprite->field_0 - dword_6779E4;
                     dword_6779F4 += (Ang16::cosine_40F520(v262) * dword_677A4C);
@@ -3461,11 +3461,11 @@ void CarAI_78::UpdateStateMachine_44E560()
                     dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * dword_677A84);
                     dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * dword_677A84);
 
-                    Fix16 v227 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v61 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v227 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v61 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
                     v245 = Fix16::Max_44E540(v61, v227);
 
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 break;
             }
@@ -3545,33 +3545,33 @@ void CarAI_78::UpdateStateMachine_44E560()
                     }
                     pHam40->field_10 = 1;
 
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
-                    dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94);
-                    dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
+                    dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94);
+                    dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94);
 
-                    Fix16 v231 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v82 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v231 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v82 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
 
                     v245 = Fix16::Max_44E540(v82, v231);
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 else
                 {
                     ++pHam40->field_2E;
 
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v259 = dword_6779E4 + dword_6779B0->field_50_car_sprite->field_0;
                     dword_6779F4 += (Ang16::cosine_40F520(v259) * dword_677A4C);
                     dword_6779F0 += (Ang16::sine_40F500(v259) * dword_677A4C);
-                    dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94);
-                    dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94);
+                    dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94);
+                    dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94);
 
-                    Fix16 v230 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                    Fix16 v77 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                    Fix16 v230 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                    Fix16 v77 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
                     v245 = Fix16::Max_44E540(v77, v230);
 
-                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                    v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 }
                 break;
             }
@@ -3580,20 +3580,20 @@ void CarAI_78::UpdateStateMachine_44E560()
             {
                 MakeAgressiveSirensAndLights_4476F0();
 
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 Ang16 v257 = dword_6779B0->field_50_car_sprite->field_0 - dword_6779E4;
 
                 dword_6779F0 += Ang16::sine_40F500(v257) * dword_677A4C;
                 dword_6779F4 += Ang16::cosine_40F520(v257) * dword_677A4C;
-                dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94 + dword_677A84);
-                dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * dword_677B94 + dword_677A84);
+                dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94 + dword_677A84);
+                dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * gF16fOne_677B94 + dword_677A84);
 
-                Fix16 v232 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v88 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v232 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v88 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
                 v245 = Fix16::Max_44E540(v88, v232);
 
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
@@ -3601,22 +3601,22 @@ void CarAI_78::UpdateStateMachine_44E560()
             {
                 MakeAgressiveSirensAndLights_4476F0();
 
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 Ang16 v261 = dword_6779E4 + dword_6779B0->field_50_car_sprite->field_0;
 
                 dword_6779F0 += (Ang16::sine_40F500(v261) * dword_677A4C);
                 dword_6779F4 += (Ang16::cosine_40F520(v261) * dword_677A4C);
 
-                Fix16 v272 = dword_677B94 + dword_677A84;
+                Fix16 v272 = gF16fOne_677B94 + dword_677A84;
 
                 dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * v272);
                 dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * v272);
 
-                Fix16 v233 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v94 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v233 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v94 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
                 v245 = Fix16::Max_44E540(v94, v233);
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 break;
             }
 
@@ -3624,21 +3624,21 @@ void CarAI_78::UpdateStateMachine_44E560()
             case 13:
             {
                 MakeAgressiveSirensAndLights_4476F0();
-                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                 dword_6779F0 += (Ang16::sine_40F500(dword_6779B0->field_50_car_sprite->field_0) * dword_677B9C);
                 dword_6779F4 += (Ang16::cosine_40F520(dword_6779B0->field_50_car_sprite->field_0) * dword_677B9C);
 
-                Fix16 v234 = Fix16::Abs_436A50(dword_6779F4 - dword_677C30);
-                Fix16 v99 = Fix16::Abs_436A50(dword_6779F0 - dword_677C38);
+                Fix16 v234 = Fix16::Abs_436A50(dword_6779F4 - gCurrCarAI_ypos_677C30);
+                Fix16 v99 = Fix16::Abs_436A50(dword_6779F0 - gCurrCarAI_xpos_677C38);
                 v245 = Fix16::Max_44E540(v99, v234);
-                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v248 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 if (pHam40->field_C != 13)
                 {
                     break;
                 }
 
-                v256 = Fix16::atan2_fixed_405320(dword_6779F4 - dword_677C30, dword_6779F0 - dword_677C38);
+                v256 = Fix16::atan2_fixed_405320(dword_6779F4 - gCurrCarAI_ypos_677C30, dword_6779F0 - gCurrCarAI_xpos_677C38);
                 if (dword_677A8C >= dword_677B58)
                 {
                     if (Ang16::IsAngleAhead_405C60(&this->field_10_angle, &v256))
@@ -3744,7 +3744,7 @@ void CarAI_78::UpdateStateMachine_44E560()
             }
         }
     LABEL_186:
-        field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+        field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
         goto LABEL_190;
     }
 
@@ -3804,7 +3804,7 @@ LABEL_190:
     //dword_6779F4 = dword_6779F4;
     if (!this->field_3C)
     {
-        field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+        field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
         Fix16 v247 = (Fix16(word_677A38.rValue) * Fix16(this->field_0->field_58_physics->field_AD_turn_direction));
         Ang16 v244;
@@ -3813,8 +3813,8 @@ LABEL_190:
         Ang16 v240 = this->field_10_angle + v244;
 
         field_0->field_50_car_sprite->set_xyz_lazy_420600(
-            (Ang16::sine_40F500(v240) * dword_677B94) + field_0->field_50_car_sprite->field_14_xy.x,
-            (Ang16::cosine_40F520(v240) * dword_677B94) + field_0->field_50_car_sprite->field_14_xy.y,
+            (Ang16::sine_40F500(v240) * gF16fOne_677B94) + field_0->field_50_car_sprite->field_14_xy.x,
+            (Ang16::cosine_40F520(v240) * gF16fOne_677B94) + field_0->field_50_car_sprite->field_14_xy.y,
             field_0->field_50_car_sprite->field_1C_zpos);
 
         if (field_0->field_50_car_sprite->CheckSpriteMovementRegion_5A2500())
@@ -3920,9 +3920,9 @@ LABEL_190:
                 }
 
                 dword_677A8C = dword_6779B0->sub_43A240();
-                if (v245 >= dword_677B94)
+                if (v245 >= gF16fOne_677B94)
                 {
-                    if (dword_677B00 >= dword_677A8C + dword_677B5C)
+                    if (gCurrCarAI_Velocity_677B00 >= dword_677A8C + dword_677B5C)
                     {
                         CarPhysics_B0* v144 = this->field_0->field_58_physics;
                         v144->field_95 = 1;
@@ -3957,12 +3957,12 @@ LABEL_190:
             case 3:
                 if (pHam40->field_2C == 10)
                 {
-                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     Ang16 v244 = dword_6779B0->field_50_car_sprite->field_0 - dword_6779E4;
 
-                    Fix16 v237 = (Ang16::sine_40F500(v244) * dword_677B94);
-                    Fix16 v241 = (Ang16::cosine_40F520(v244) * dword_677B94);
+                    Fix16 v237 = (Ang16::sine_40F500(v244) * gF16fOne_677B94);
+                    Fix16 v241 = (Ang16::cosine_40F520(v244) * gF16fOne_677B94);
 
                     field_0->field_50_car_sprite->set_xyz_lazy_420600(v237 + field_0->field_50_car_sprite->field_14_xy.x,
                                                                       v241 + field_0->field_50_car_sprite->field_14_xy.y,
@@ -3982,9 +3982,9 @@ LABEL_190:
                 else
                 {
                     dword_677A8C = dword_6779B0->sub_43A240();
-                    if (v245 >= dword_677B94)
+                    if (v245 >= gF16fOne_677B94)
                     {
-                        if (dword_677B00 >= dword_677A8C)
+                        if (gCurrCarAI_Velocity_677B00 >= dword_677A8C)
                         {
                             CarPhysics_B0* v161 = this->field_0->field_58_physics;
                             v161->field_95 = 1;
@@ -4021,11 +4021,11 @@ LABEL_190:
                 if (pHam40->field_2C < 0xAu)
                 {
                     dword_677A8C = dword_6779B0->sub_43A240();
-                    if (v245 < dword_677B94)
+                    if (v245 < gF16fOne_677B94)
                     {
                         field_0->field_58_physics->ClearDriverInputs_453F90();
                     }
-                    else if (dword_677B00 < dword_677A8C)
+                    else if (gCurrCarAI_Velocity_677B00 < dword_677A8C)
                     {
                         field_0->field_58_physics->ForceForwardAcceleration_453F70();
                     }
@@ -4041,14 +4041,14 @@ LABEL_190:
                 }
                 else
                 {
-                    field_0->field_50_car_sprite->set_xyz_lazy_451950(dword_6779F0, dword_6779F4, dword_677C48);
+                    field_0->field_50_car_sprite->set_xyz_lazy_451950(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                     // Ang16::sub_4516F0 - inlined operator+
                     Ang16 v206 = dword_6779B0->field_50_car_sprite->field_0 + dword_6779E4;
 
                     //  Ang16::sub_451730 - inlined PolarToCartesian_41FC20 ?
                     Fix16 v237;
-                    Ang16::PolarToCartesian_41FC20(v206, dword_677B94, v237, v241);
+                    Ang16::PolarToCartesian_41FC20(v206, gF16fOne_677B94, v237, v241);
 
                     Fix16 v235 = field_0->field_50_car_sprite->field_1C_zpos;
                     Fix16 v218 = (field_0->field_50_car_sprite->field_14_xy.y + v241);
@@ -4145,11 +4145,11 @@ LABEL_190:
                                 dword_677A8C = this->field_74;
                             }
 
-                            if (v245 >= dword_677B94)
+                            if (v245 >= gF16fOne_677B94)
                             {
-                                if (dword_677B00 >= dword_677A8C)
+                                if (gCurrCarAI_Velocity_677B00 >= dword_677A8C)
                                 {
-                                    if (dword_677B00 <= dword_677A8C + dword_677B5C)
+                                    if (gCurrCarAI_Velocity_677B00 <= dword_677A8C + dword_677B5C)
                                     {
                                         field_0->field_58_physics->ForceNeutralInput_453F50();
                                     }
@@ -4174,7 +4174,7 @@ LABEL_190:
                             }
                             else
                             {
-                                if (dword_677B00 > dword_677A8C + dword_677B5C)
+                                if (gCurrCarAI_Velocity_677B00 > dword_677A8C + dword_677B5C)
                                 {
                                     //goto LABEL_292;
                                     field_0->sub_43A950();
@@ -4194,11 +4194,11 @@ LABEL_190:
                                 goto LABEL_273;
                             }
 
-                            field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                            field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                             v253 = dword_6779B0->field_50_car_sprite->field_0 - dword_6779E4;
-                            v237 = (Ang16::sine_40F500(v253) * dword_677B94);
-                            v241 = (Ang16::cosine_40F520(v253) * dword_677B94);
+                            v237 = (Ang16::sine_40F500(v253) * gF16fOne_677B94);
+                            v241 = (Ang16::cosine_40F520(v253) * gF16fOne_677B94);
 
                             field_0->field_50_car_sprite->set_xyz_lazy_420600(v237 + field_0->field_50_car_sprite->field_14_xy.x,
                                                                               v241 + field_0->field_50_car_sprite->field_14_xy.y,
@@ -4213,8 +4213,8 @@ LABEL_190:
                                                                                             sprite_types_enum::unknown_0);
                             if (!field_70)
                             {
-                                v237 = (Ang16::sine_40F500(field_0->field_50_car_sprite->field_0) * dword_677B94);
-                                v241 = (Ang16::cosine_40F520(field_0->field_50_car_sprite->field_0) * dword_677B94);
+                                v237 = (Ang16::sine_40F500(field_0->field_50_car_sprite->field_0) * gF16fOne_677B94);
+                                v241 = (Ang16::cosine_40F520(field_0->field_50_car_sprite->field_0) * gF16fOne_677B94);
 
                                 field_0->field_50_car_sprite->set_xyz_lazy_420600(v237 + field_0->field_50_car_sprite->field_14_xy.x,
                                                                                   v241 + field_0->field_50_car_sprite->field_14_xy.y,
@@ -4228,11 +4228,11 @@ LABEL_190:
                             LABEL_273:
                                 if (v243)
                                 {
-                                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, dword_677C48);
+                                    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_6779F0, dword_6779F4, gCurrCarAI_zpos_677C48);
 
                                     Ang16 v254 = dword_6779E4 + dword_6779B0->field_50_car_sprite->field_0;
-                                    Fix16 v237 = (Ang16::sine_40F500(v254) * dword_677B94);
-                                    Fix16 v241 = (Ang16::cosine_40F520(v254) * dword_677B94);
+                                    Fix16 v237 = (Ang16::sine_40F500(v254) * gF16fOne_677B94);
+                                    Fix16 v241 = (Ang16::cosine_40F520(v254) * gF16fOne_677B94);
                                     field_0->field_50_car_sprite->set_xyz_lazy_420600(v237 + field_0->field_50_car_sprite->field_14_xy.x,
                                                                                       v241 + field_0->field_50_car_sprite->field_14_xy.y,
                                                                                       field_0->field_50_car_sprite->field_1C_zpos);
@@ -4243,8 +4243,8 @@ LABEL_190:
                                             gPurpleDoom_1_679208->FindNearestSpriteOfType_477E60(this->field_0->field_50_car_sprite, 0);
                                         if (!this->field_70)
                                         {
-                                            Fix16 v237 = (Ang16::sine_40F500(field_0->field_50_car_sprite->field_0) * dword_677B94);
-                                            Fix16 v196 = (Ang16::cosine_40F520(field_0->field_50_car_sprite->field_0) * dword_677B94);
+                                            Fix16 v237 = (Ang16::sine_40F500(field_0->field_50_car_sprite->field_0) * gF16fOne_677B94);
+                                            Fix16 v196 = (Ang16::cosine_40F520(field_0->field_50_car_sprite->field_0) * gF16fOne_677B94);
 
                                             field_0->field_50_car_sprite->set_xyz_lazy_420600(
                                                 v237 + field_0->field_50_car_sprite->field_14_xy.x,
@@ -4304,7 +4304,7 @@ LABEL_190:
                 dword_677A8C = dword_6779B0->sub_43A240();
                 if (v245 < dword_6779BC)
                 {
-                    if (dword_677B00 > dword_677A8C)
+                    if (gCurrCarAI_Velocity_677B00 > dword_677A8C)
                     {
                         //LABEL_292:
                         field_0->sub_43A950();
@@ -4315,14 +4315,14 @@ LABEL_190:
                     return;
                 }
 
-                if (v245 > dword_677A4C || dword_677B00 < dword_677A8C)
+                if (v245 > dword_677A4C || gCurrCarAI_Velocity_677B00 < dword_677A8C)
                 {
                     //LABEL_324:
                     field_0->field_58_physics->ForceForwardAcceleration_453F70();
                 }
                 else
                 {
-                    if (dword_677B00 > (dword_677A8C + dword_677B5C))
+                    if (gCurrCarAI_Velocity_677B00 > (dword_677A8C + dword_677B5C))
                     {
                         //LABEL_320:
                         field_0->field_58_physics->ClearDriverInputs_453F90();
@@ -4342,7 +4342,7 @@ LABEL_190:
 
             case 12:
             case 13:
-                if (v245 < (dword_677B94 + dword_677A84))
+                if (v245 < (gF16fOne_677B94 + dword_677A84))
                 {
                     ++pHam40->field_3C;
                     field_0->field_58_physics->ClearDriverInputs_453F90();
@@ -4361,7 +4361,7 @@ void CarAI_78::sub_451980()
 {
     WIP_IMPLEMENTED;
     
-    Fix16 v2 = dword_677B94;
+    Fix16 v2 = gF16fOne_677B94;
     bool flag1 = false;
     u8 bUnknown = 0;
     Car_BC* cBC = field_70->field_8_car_bc_ptr;
@@ -4389,8 +4389,8 @@ void CarAI_78::sub_451980()
         }
     }
 
-    Fix16 v8 = Fix16::MaxAbsDistance_42A6B0(dword_677C38,
-                                            dword_677C30,
+    Fix16 v8 = Fix16::MaxAbsDistance_42A6B0(gCurrCarAI_xpos_677C38,
+                                            gCurrCarAI_ypos_677C30,
                                             cBC->field_50_car_sprite->field_14_xy.x,
                                             cBC->field_50_car_sprite->field_14_xy.y);
     Ang16 v9;
@@ -4453,7 +4453,7 @@ void CarAI_78::sub_451980()
                         }
                         else
                         {
-                            if (dword_677B00 >= dword_677B90)
+                            if (gCurrCarAI_Velocity_677B00 >= dword_677B90)
                             {
                                 field_0->field_58_physics->sub_42ABC0();
                             }
@@ -4463,7 +4463,7 @@ void CarAI_78::sub_451980()
                             }
                         }
                     }
-                    else if (dword_677B00 >= dword_677A8C)
+                    else if (gCurrCarAI_Velocity_677B00 >= dword_677A8C)
                     {
                         field_0->field_58_physics->sub_42ABC0();
                     }
@@ -4542,8 +4542,8 @@ void CarAI_78::sub_451980()
                             }
                             else
                             {
-                                Fix16 pMaybeY_FP16 = cBC->field_50_car_sprite->field_14_xy.x - dword_677C38;
-                                Fix16 pMaybeX_FP16 = cBC->field_50_car_sprite->field_14_xy.y - dword_677C30;
+                                Fix16 pMaybeY_FP16 = cBC->field_50_car_sprite->field_14_xy.x - gCurrCarAI_xpos_677C38;
+                                Fix16 pMaybeX_FP16 = cBC->field_50_car_sprite->field_14_xy.y - gCurrCarAI_ypos_677C30;
 
                                 Ang16 v21 = Fix16::atan2_fixed_405320(pMaybeX_FP16, pMaybeY_FP16);
 
@@ -4601,7 +4601,7 @@ void CarAI_78::sub_451980()
             }
         }
     }
-    else if (dword_677B00 == dword_677B90)
+    else if (gCurrCarAI_Velocity_677B00 == dword_677B90)
     {
         if ((field_24_flags & 0x90) == 0)
         {
@@ -4618,7 +4618,7 @@ void CarAI_78::sub_451980()
         byte_677B3C = 0;
         if ((field_24_flags & 0x1000) == 0 || field_68->field_7C_uni_num != 2)
         {
-            if (dword_677B00 > dword_6779C8)
+            if (gCurrCarAI_Velocity_677B00 > dword_6779C8)
             {
                 field_0->sub_43A970();
             }
@@ -4653,7 +4653,7 @@ void CarAI_78::sub_451FF0()
         if (!byte_677BBC || (field_0->field_60->field_8_maybe_path_type != 5) ||
             field_0->field_60->field_30_ped_to_follow != field_70->field_8_char_b4_ptr->field_7C_pPed)
         {
-            if (dword_677B00 > dword_6779C8)
+            if (gCurrCarAI_Velocity_677B00 > dword_6779C8)
             {
                 field_0->sub_43A970();
                 byte_677B3C = 0;
@@ -4673,19 +4673,19 @@ void CarAI_78::sub_452060()
     WIP_IMPLEMENTED;
 
     Fix16 v1;
-    v1 = dword_677B94;
+    v1 = gF16fOne_677B94;
 
     byte_677B8C = 1;
     byte_677B3C = 1;
 
-    Fix16 v85 = dword_677B94;
+    Fix16 v85 = gF16fOne_677B94;
 
     Car_BC* pCar = this->field_0;
 
     if (pCar->field_7C_uni_num == 2)
     {
         this->field_24_flags &= ~0x10;
-        v1 = dword_677B94;
+        v1 = gF16fOne_677B94;
     }
 
     Fix16 new_z;
@@ -4722,15 +4722,15 @@ void CarAI_78::sub_452060()
 
     if (this->field_24_flags & 0x80)
     {
-        field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+        field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
         v86 = (Fix16(word_677A38.rValue) * Fix16(this->field_0->field_58_physics->field_AD_turn_direction));
         v83.sub_4516B0(&v86, 0); // ctor ?
 
         v82 = v83 + this->field_10_angle;
 
-        new_x_1 = (Ang16::sine_40F500(v82) * dword_677B94) + field_0->field_50_car_sprite->field_14_xy.x;
-        new_y_2 = (Ang16::cosine_40F520(v82) * dword_677B94) + field_0->field_50_car_sprite->field_14_xy.y;
+        new_x_1 = (Ang16::sine_40F500(v82) * gF16fOne_677B94) + field_0->field_50_car_sprite->field_14_xy.x;
+        new_y_2 = (Ang16::cosine_40F520(v82) * gF16fOne_677B94) + field_0->field_50_car_sprite->field_14_xy.y;
 
         this->field_0->field_50_car_sprite->set_xyz_lazy_420600(new_x_1, new_y_2, new_z);
 
@@ -4742,7 +4742,7 @@ void CarAI_78::sub_452060()
     this->field_70 = gPurpleDoom_1_679208->FindNearestSpriteOfType_477E60(this->field_0->field_50_car_sprite, 0);
     if (!this->field_70 || byte_677C90)
     {
-        field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+        field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
         v9 = (Ang16::sine_40F500(this->field_10_angle) * v85);
         v10 = (Ang16::cosine_40F520(this->field_10_angle) * v85);
@@ -4763,13 +4763,13 @@ LABEL_31:
             Fix16 new_y_5 = v10 + field_0->field_50_car_sprite->field_14_xy.y;
             Fix16 new_x_3 = v9 + field_0->field_50_car_sprite->field_14_xy.x;
 
-            field_0->field_50_car_sprite->set_xyz_lazy_420600(new_x_3, new_y_5, zpos_ - dword_677B94);
+            field_0->field_50_car_sprite->set_xyz_lazy_420600(new_x_3, new_y_5, zpos_ - gF16fOne_677B94);
             new_z = zpos_;
             this->field_70 = gPurpleDoom_1_679208->FindNearestSpriteOfType_477E60(this->field_0->field_50_car_sprite, 0);
         }
     }
 
-    field_0->field_50_car_sprite->set_xyz_lazy_420600(dword_677C38, dword_677C30, dword_677C48);
+    field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
     char_type bCheckMovement;
 
@@ -4779,8 +4779,8 @@ LABEL_31:
     Fix16 new_x_4;
     if ((this->field_24_flags & 0x40) == 0)
     {
-        v52 = (Ang16::sine_40F500(this->field_10_angle) * dword_677B94);
-        v53 = (Ang16::cosine_40F520(this->field_10_angle) * dword_677B94);
+        v52 = (Ang16::sine_40F500(this->field_10_angle) * gF16fOne_677B94);
+        v53 = (Ang16::cosine_40F520(this->field_10_angle) * gF16fOne_677B94);
 
         new_y_7 = v53 + field_0->field_50_car_sprite->field_14_xy.y;
         new_x_4 = v52 + field_0->field_50_car_sprite->field_14_xy.x;
@@ -4881,7 +4881,7 @@ LABEL_31:
     LABEL_76:
         byte_677BBC = 0;
         this->field_24_flags &= ~0x80u;
-        if (dword_677B00 == dword_677B90)
+        if (gCurrCarAI_Velocity_677B00 == dword_677B90)
         {
             this->field_5A = 0;
             this->field_24_flags |= 0x40;
@@ -4896,7 +4896,7 @@ LABEL_31:
         {
             byte_677B8C = 1;
             byte_677B3C = 0;
-            if (dword_677B00 <= dword_6779C8)
+            if (gCurrCarAI_Velocity_677B00 <= dword_6779C8)
             {
                 field_0->sub_43A950();
             }
@@ -4915,7 +4915,7 @@ LABEL_31:
         {
             pBlock = gMap_0x370_6F6268->get_block_452980(f70->field_14_xy.x.ToInt(),
                                                          f70->field_14_xy.y.ToInt(),
-                                                         (f70->field_1C_zpos - dword_677B94).ToInt());
+                                                         (f70->field_1C_zpos - gF16fOne_677B94).ToInt());
             if (!pBlock || (pBlock->field_B_slope_type & 3) != 1)
             {
                 goto LABEL_104;
@@ -4949,7 +4949,7 @@ LABEL_31:
 
         gmp_block_info* pBlock_ = gMap_0x370_6F6268->get_block_452980(f70->field_14_xy.x.ToInt(),
                                                                       f70->field_14_xy.y.ToInt(),
-                                                                      (f70->field_1C_zpos - dword_677B94).ToInt());
+                                                                      (f70->field_1C_zpos - gF16fOne_677B94).ToInt());
         if (pBlock_ && (pBlock_->field_B_slope_type & 3) == 1)
         {
             goto LABEL_99;
@@ -5027,7 +5027,7 @@ LABEL_104:
 
         if ((field_24_flags & 0x80u) == 0 && (field_24_flags & 0x4500) == 0)
         {
-            if (dword_677B00 < dword_677A8C)
+            if (gCurrCarAI_Velocity_677B00 < dword_677A8C)
             {
                 CarPhysics_B0* pPhysics = this->field_0->field_58_physics;
                 pPhysics->field_93_is_forward_gas_on = 1;
@@ -5051,7 +5051,7 @@ LABEL_104:
             v81 = this->field_74;
         }
 
-        if (dword_677B00 < v81)
+        if (gCurrCarAI_Velocity_677B00 < v81)
         {
             CarPhysics_B0* pPhysics = this->field_0->field_58_physics;
             pPhysics->field_93_is_forward_gas_on = 1;
@@ -5061,11 +5061,11 @@ LABEL_104:
             return;
         }
 
-        if (dword_677B00 <= dword_6779B8)
+        if (gCurrCarAI_Velocity_677B00 <= dword_6779B8)
         {
-            if (dword_677B00 <= dword_677B78)
+            if (gCurrCarAI_Velocity_677B00 <= dword_677B78)
             {
-                if (dword_677B00 > v81)
+                if (gCurrCarAI_Velocity_677B00 > v81)
                 {
                     CarPhysics_B0* pPhysics_ = this->field_0->field_58_physics;
                     pPhysics_->field_95 = 1;
@@ -5146,8 +5146,8 @@ void CarAI_78::sub_452A20()
 
         Fix16 p_field_14_xy = field_68->field_50_car_sprite->field_14_xy.x;
 
-        Fix16 rotX = (((p_field_14_xy - dword_677C38) * Ang16::cosine_40F520(v35)) + ((p_y - dword_677C30) * Ang16::sine_40F500(v35)));
-        Fix16 rotY = ((-(p_field_14_xy - dword_677C38) * Ang16::sine_40F500(v35)) + ((p_y - dword_677C30) * Ang16::cosine_40F520(v35)));
+        Fix16 rotX = (((p_field_14_xy - gCurrCarAI_xpos_677C38) * Ang16::cosine_40F520(v35)) + ((p_y - gCurrCarAI_ypos_677C30) * Ang16::sine_40F500(v35)));
+        Fix16 rotY = ((-(p_field_14_xy - gCurrCarAI_xpos_677C38) * Ang16::sine_40F500(v35)) + ((p_y - gCurrCarAI_ypos_677C30) * Ang16::cosine_40F520(v35)));
 
         Fix16 v21 = this->field_0->field_50_car_sprite->field_14_xy.x + rotX;
 
@@ -5246,7 +5246,7 @@ void CarAI_78::sub_452A20()
             byte_677A5D = 0;
         }
 
-        if ((this->field_24_flags & 0x200000) != 0 && this->field_2A < 0x3Cu && dword_677B00 < dword_677B58)
+        if ((this->field_24_flags & 0x200000) != 0 && this->field_2A < 0x3Cu && gCurrCarAI_Velocity_677B00 < dword_677B58)
         {
             CarPhysics_B0* v30 = this->field_0->field_58_physics;
             v30->field_93_is_forward_gas_on = 1;
@@ -5268,6 +5268,7 @@ void CarAI_78::sub_452A20()
     }
 }
 
+// https://decomp.me/scratch/uZlwP
 WIP_FUNC(0x452df0)
 void CarAI_78::sub_452DF0()
 {
@@ -5275,11 +5276,11 @@ void CarAI_78::sub_452DF0()
 
     byte_677A5D = 1;
     u8 v23 = 0;
-    dword_677C38 = this->field_0->field_50_car_sprite->field_14_xy.x;
-    dword_677C30 = this->field_0->field_50_car_sprite->field_14_xy.y;
+    gCurrCarAI_xpos_677C38 = this->field_0->field_50_car_sprite->field_14_xy.x;
+    gCurrCarAI_ypos_677C30 = this->field_0->field_50_car_sprite->field_14_xy.y;
     Fix16 zpos = this->field_0->field_50_car_sprite->field_1C_zpos;
     dword_6779B0 = 0;
-    dword_677C48 = zpos;
+    gCurrCarAI_zpos_677C48 = zpos;
     byte_677CA8 = 0;
 
     if (!this->field_0->field_60 || this->field_3C)
@@ -5389,7 +5390,7 @@ void CarAI_78::sub_452DF0()
 
     sub_452060();
 
-    if (dword_677B00 != dword_677B90)
+    if (gCurrCarAI_Velocity_677B00 != dword_677B90)
     {
         // TODO: Use dword_677B90  as Kzero
         Fix16 v14 = field_0->field_58_physics->field_0_vel_read_only.GetLength_2();
@@ -5470,11 +5471,11 @@ void CarAI_78::sub_453470()
 {
     this->field_0->field_58_physics->field_92_is_hand_brake_on = 0;
     Fix16 t = field_0->field_58_physics->field_40_linvel_1.GetLength_453590();
-    dword_677B00 = t;
+    gCurrCarAI_Velocity_677B00 = t;
 
     if (this->field_0->field_80)
     {
-        this->field_0->field_A6 |= 0x20u;
+        this->field_0->field_A6 |= 0x20u; // stop the vehicle
     }
 
     if (this->field_30 > 0)
@@ -5483,7 +5484,7 @@ void CarAI_78::sub_453470()
 
         if (this->field_30)
         {
-            this->field_0->field_A6 |= 0x20;
+            this->field_0->field_A6 |= 0x20; // stop the vehicle
         }
         else
         {
@@ -5491,11 +5492,11 @@ void CarAI_78::sub_453470()
         }
     }
 
-    if ((this->field_0->field_A6 & 0x20) == 0x20)
+    if ((this->field_0->field_A6 & 0x20) == 0x20) // if the vehicle is forced to stop
     {
         if (this->field_24_bf.b20)
         {
-            if (dword_677B00 > dword_677B60)
+            if (gCurrCarAI_Velocity_677B00 > dword_677B60)
             {
                 field_0->sub_43A970();
             }
@@ -5508,7 +5509,7 @@ void CarAI_78::sub_453470()
         }
         else
         {
-            if (dword_677B00 > dword_677B60)
+            if (gCurrCarAI_Velocity_677B00 > dword_677B60)
             {
                 field_0->sub_43A970(); // gas on
             }
@@ -5526,7 +5527,7 @@ void CarAI_78::sub_453470()
     }
     else
     {
-        sub_452DF0();
+        sub_452DF0(); // if the vehicle is free to go: do AI stuff
     }
 }
 
@@ -5677,12 +5678,12 @@ void __stdcall sub_447650()
     byte_677B8C = 1;
     byte_677CA8 = 0;
     byte_677C06 = 0;
-    dword_677C38 = dword_677B90;
-    dword_677C30 = dword_677B90;
-    dword_677C48 = dword_677B90;
+    gCurrCarAI_xpos_677C38 = dword_677B90;
+    gCurrCarAI_ypos_677C30 = dword_677B90;
+    gCurrCarAI_zpos_677C48 = dword_677B90;
     dword_677A74 = dword_677B90;
     dword_677A80 = dword_677B90;
-    dword_677B00 = dword_677B90;
+    gCurrCarAI_Velocity_677B00 = dword_677B90;
     dword_677C9C = dword_677B90;
     dword_677A8C = dword_677B90;
     dword_6779F0 = dword_677B90;

--- a/Source/CarAI_78.cpp
+++ b/Source/CarAI_78.cpp
@@ -5275,15 +5275,15 @@ void CarAI_78::sub_452DF0()
     WIP_IMPLEMENTED;
 
     byte_677A5D = 1;
-    u8 v23 = 0;
-    gCurrCarAI_xpos_677C38 = this->field_0->field_50_car_sprite->field_14_xy.x;
-    gCurrCarAI_ypos_677C30 = this->field_0->field_50_car_sprite->field_14_xy.y;
-    Fix16 zpos = this->field_0->field_50_car_sprite->field_1C_zpos;
+    bool bUpdateStateMachine = false;
+    gCurrCarAI_xpos_677C38 = field_0->field_50_car_sprite->field_14_xy.x;
+    gCurrCarAI_ypos_677C30 = field_0->field_50_car_sprite->field_14_xy.y;
+    Fix16 zpos = field_0->field_50_car_sprite->field_1C_zpos;
     dword_6779B0 = 0;
     gCurrCarAI_zpos_677C48 = zpos;
     byte_677CA8 = 0;
 
-    if (!this->field_0->field_60 || this->field_3C)
+    if (!field_0->field_60 || field_3C)
     {
         byte_677BBC = 0;
     }
@@ -5293,20 +5293,20 @@ void CarAI_78::sub_452DF0()
         byte_677CA8 = 1;
     }
 
-    gmp_block_info* pBlock = gMap_0x370_6F6268->get_block_4DFE10(this->field_0->field_50_car_sprite->field_14_xy.x.ToInt(),
-                                                                 this->field_0->field_50_car_sprite->field_14_xy.y.ToInt(),
-                                                                 this->field_0->field_50_car_sprite->field_1C_zpos.ToInt());
+    gmp_block_info* pBlock = gMap_0x370_6F6268->get_block_4DFE10(field_0->field_50_car_sprite->field_14_xy.x.ToInt(),
+                                                                 field_0->field_50_car_sprite->field_14_xy.y.ToInt(),
+                                                                 field_0->field_50_car_sprite->field_1C_zpos.ToInt());
 
-    if (pBlock && (pBlock->field_B_slope_type & 0xFC) != 0 && (pBlock->field_B_slope_type & 0xFCu) < 0xB4 &&
+    if (pBlock && (pBlock->field_B_slope_type & 0xFC) > 0 && (pBlock->field_B_slope_type & 0xFCu) < 0xB4 &&
         (pBlock->field_B_slope_type & 3) != 0)
     {
         byte_677C90 = 1;
     }
     else
     {
-        pBlock = gMap_0x370_6F6268->get_block_4DFE10(this->field_0->field_50_car_sprite->field_14_xy.x.ToInt(),
-                                                     this->field_0->field_50_car_sprite->field_14_xy.y.ToInt(),
-                                                     (this->field_0->field_50_car_sprite->field_1C_zpos.ToInt()) - 1);
+        pBlock = gMap_0x370_6F6268->get_block_4DFE10(field_0->field_50_car_sprite->field_14_xy.x.ToInt(),
+                                                     field_0->field_50_car_sprite->field_14_xy.y.ToInt(),
+                                                     (field_0->field_50_car_sprite->field_1C_zpos.ToInt()) - 1);
         byte_677C90 = 0;
     }
 
@@ -5319,70 +5319,69 @@ void CarAI_78::sub_452DF0()
         byte_677C06 = 0;
     }
 
-    this->field_24_flags |= 0x2000;
+    field_24_bf.b13 = true;
     byte_677A5C = 0;
 
-    this->field_4C_curr_direction = Ang16::GetAngleFace_4F78F0(this->field_10_angle);
+    field_4C_curr_direction = Ang16::GetAngleFace_4F78F0(field_10_angle);
     dword_677A8C = field_74;
-    dword_677C9C = dword_6F6850.list[gGtx_0x106C_703DD4->get_car_info_5AA3B0(this->field_0->field_84_car_info_idx)->h];
+    dword_677C9C = dword_6F6850.list[gGtx_0x106C_703DD4->get_car_info_5AA3B0(field_0->field_84_car_info_idx)->h];
 
-    Car_BC* v7 = this->field_0;
-    s32 v8 = this->field_24_flags & ~0x200000u | ((this->field_0->field_54_driver->field_21C & 8) << 18);
-    this->field_24_flags = v8;
+    field_24_flags = field_24_flags & ~0x200000u | ((field_0->field_54_driver->field_21C & 8) << 18);
 
     if (byte_677BBC)
     {
-        if (!v7->field_60->field_22)
+        if (!field_0->field_60->field_22)
         {
-            v23 = 1;
-            this->field_24_flags = v8 | 0x200000;
+            bUpdateStateMachine = true;
+            field_24_bf.b21 = true;
         }
     }
 
-    if (this->field_3C)
+    if (field_3C)
     {
-        ++this->field_58;
-        if (v7->field_7C_uni_num == 5)
+        ++field_58;
+        if (field_0->field_7C_uni_num != 5)
         {
-            this->field_58 = 0;
+            if (field_58 > 0xC8u)
+            {
+                field_0->field_80 = 1;
+            }
         }
-        else if (this->field_58 > 0xC8u)
+        else
         {
-            v7->field_80 = 1;
-        }
-        v23 = 0;
-        if ((this->field_24_flags & 0x40) != 0)
-        {
-            this->field_50 = 3;
+            field_58 = 0;
         }
 
-        switch (this->field_50)
+        bUpdateStateMachine = false;
+        if ((field_24_flags & 0x40) != 0)
+        {
+            field_50 = 3;
+        }
+
+        switch (field_50)
         {
             case 0:
-                this->field_24_flags &= ~0x20C0u;
+                field_24_flags &= ~0x20C0u;
                 field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
                 field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
                 break;
 
             case 1:
-                this->field_24_flags &= ~0x2040u;
+                field_24_flags &= ~0x2040u;
                 field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::anticlockwise_1;
-                this->field_24_flags |= 0x80;
+                field_24_flags |= 0x80;
                 break;
 
             case 2:
-                this->field_24_flags &= ~0x2040u;
-                this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::clockwise_m1;
-                this->field_24_flags |= 0x80;
+                field_24_flags &= ~0x2040u;
+                field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::clockwise_m1;
+                field_24_flags |= 0x80;
                 break;
 
             case 3:
-            {
-                s32 v11 = this->field_24_flags & ~0x2080u;
-                v11 = this->field_24_flags & ~0xC0 | 0x40;
-                this->field_24_flags = v11;
-            }
-            break;
+                field_24_flags = (field_24_flags & ~0x2080u) | 0x40;
+                break;
+
             default:
                 break;
         }
@@ -5393,64 +5392,60 @@ void CarAI_78::sub_452DF0()
     if (gCurrCarAI_Velocity_677B00 != dword_677B90)
     {
         // TODO: Use dword_677B90  as Kzero
-        Fix16 v14 = field_0->field_58_physics->field_0_vel_read_only.GetLength_2();
-        if (v14 == dword_677B90)
+        if (field_0->field_58_physics->field_0_vel_read_only.GetLength_2() == dword_677B90)
         {
-            //LABEL_41:
-            ++this->field_2A;
+            ++field_2A;
         }
         else
         {
-            this->field_2A = 0;
+            field_2A = 0;
         }
     }
     else
     {
-        // goto LABEL_41;
-        ++this->field_2A;
+        ++field_2A;
     }
 
     sub_452A20();
 
-    if (v23)
+    if (bUpdateStateMachine)
     {
         UpdateStateMachine_44E560();
     }
 
-    Hamburger_40* v15 = this->field_0->field_60;
-    if (v15 && v15->field_8_maybe_path_type == 2)
+    //Hamburger_40* v15 = field_0->field_60;
+    if (field_0->field_60 && field_0->field_60->field_8_maybe_path_type == 2)
     {
         byte_677BBC = 1;
     }
     else if (!byte_677BBC)
     {
-        if (field_70 && field_70->get_type_416B40() == sprite_types_enum::unknown_1 &&
-            field_70->field_8_object_2C_ptr->field_18_model == 122)
+        if (field_70 && field_70->get_type_416B40() == sprite_types_enum::unknown_1 && field_70->As2C_40FEC0()->field_18_model == 122)
         {
-            this->field_70 = 0;
-            this->field_24_flags |= 0x10;
+            field_70 = 0;
+            field_24_flags |= 0x10;
         }
         else
         {
-            this->field_24_flags &= 0xEF;
+            field_24_flags &= 0xEF;
         }
     }
 
-    if (this->field_28_junc_idx > 0 && (this->field_24_flags & 0x10) != 0)
+    if (field_28_junc_idx > 0 && (field_24_flags & 0x10) != 0)
     {
-        Hamburger_40* v19 = this->field_0->field_60;
-        if (v19)
+        //Hamburger_40* v19 = field_0->field_60;
+        if (field_0->field_60)
         {
-            if (v19->field_22 == 1)
+            if (field_0->field_60->field_22 == 1)
             {
                 sub_447970();
             }
         }
     }
 
-    if (!byte_677A5D || this->field_54)
+    if (!byte_677A5D || field_54)
     {
-        this->field_24_flags &= 0x2000u;
+        field_24_bf.b13 = false;
     }
     else
     {
@@ -5459,11 +5454,11 @@ void CarAI_78::sub_452DF0()
 
     if (byte_677A5C)
     {
-        this->field_24_flags |= 0x2000u;
+        field_24_bf.b13 = true;
     }
 
-    this->field_68 = 0;
-    this->field_24_flags &= ~0x1000u;
+    field_68 = 0;
+    field_24_bf.b12 = false;
 }
 
 MATCH_FUNC(0x453470)

--- a/Source/CarAI_78.cpp
+++ b/Source/CarAI_78.cpp
@@ -13,7 +13,7 @@
 #include "rng.hpp"
 
 DEFINE_GLOBAL(Ang16, word_677CE8, 0x677CE8);
-DEFINE_GLOBAL(Fix16, dword_677B90, 0x677B90);
+DEFINE_GLOBAL(Fix16, kF16Zero_677B90, 0x677B90);
 DEFINE_GLOBAL(Fix16, gCurrCarAI_ypos_677C30, 0x677C30);
 DEFINE_GLOBAL(Fix16, gCurrCarAI_xpos_677C38, 0x677C38);
 DEFINE_GLOBAL(Fix16, gCurrCarAI_zpos_677C48, 0x677C48);
@@ -38,7 +38,7 @@ DEFINE_GLOBAL_INIT(Fix16, dword_677B60, Fix16(0x333, 0), 0x677B60);
 DEFINE_GLOBAL(u8, byte_677BBC, 0x677BBC);
 DEFINE_GLOBAL(u8, byte_677B3C, 0x677B3C);
 DEFINE_GLOBAL(u8, byte_677A78, 0x677A78);
-DEFINE_GLOBAL(u8, byte_677C90, 0x677C90);
+DEFINE_GLOBAL(u8, bIsOnGradientSlope_677C90, 0x677C90);
 DEFINE_GLOBAL(u8, byte_677A5D, 0x677A5D);
 DEFINE_GLOBAL(u8, byte_677A6C, 0x677A6C);
 DEFINE_GLOBAL(u8, byte_677A94, 0x677A94);
@@ -721,7 +721,7 @@ void CarAI_78::sub_4482C0()
                             v17->field_6C = 0;
                         }
                     }
-                    if (field_70->field_8_car_bc_ptr->sub_43A240() > dword_677B90)
+                    if (field_70->field_8_car_bc_ptr->sub_43A240() > kF16Zero_677B90)
                     {
                         field_0->sub_43A950();
                     }
@@ -919,7 +919,7 @@ void CarAI_78::sub_448770()
 {
     WIP_IMPLEMENTED;
 
-    Fix16 toUse = dword_677B90;
+    Fix16 toUse = kF16Zero_677B90;
     gmp_block_info* pBlock_ = 0;
     Sprite* obj_5C_f58 = gObject_5C_6F8F84->field_58;
     Sprite* pCarSprite = this->field_0->field_50_car_sprite;
@@ -941,7 +941,7 @@ void CarAI_78::sub_448770()
     Fix16 y_v = y_off + this->field_0->field_50_car_sprite->field_14_xy.y;
     dword_677A80 = y_v;
 
-    if (x_v > dword_677B90 && y_v > dword_677B90 && x_v < dword_677950 && y_v < dword_677950)
+    if (x_v > kF16Zero_677B90 && y_v > kF16Zero_677B90 && x_v < dword_677950 && y_v < dword_677950)
     {
         pBlock_ = gMap_0x370_6F6268->get_block_4DFE10(x_v.ToInt(), y_v.ToInt(), field_0->field_50_car_sprite->field_1C_zpos.ToInt());
         if (pBlock_ && (pBlock_->field_B_slope_type & 0xFC) > 0 &&
@@ -1042,7 +1042,7 @@ void CarAI_78::sub_448770()
     Fix16 y_v_ = y_off_ + this->field_0->field_50_car_sprite->field_14_xy.y;
     dword_677A80 = y_v_;
 
-    if (x_v_ > dword_677B90 && y_v_ > dword_677B90 && x_v_ < dword_677950 && y_v_ < dword_677950)
+    if (x_v_ > kF16Zero_677B90 && y_v_ > kF16Zero_677B90 && x_v_ < dword_677950 && y_v_ < dword_677950)
     {
         pBlock___ = gMap_0x370_6F6268->get_block_4DFE10(x_v_.ToInt(), y_v_.ToInt(), field_0->field_50_car_sprite->field_1C_zpos.ToInt());
         if (pBlock___ && (pBlock___->field_B_slope_type & 0xFC) > 0 &&
@@ -1063,7 +1063,7 @@ void CarAI_78::sub_448770()
 
     Fix16 y_v__ = (Ang16::cosine_40F520(this->field_10_angle) * dword_677B9C) + this->field_0->field_50_car_sprite->field_14_xy.y;
     dword_677A80 = y_v__;
-    if (x_v__ <= dword_677B90 || y_v__ <= dword_677B90 || x_v__ >= dword_677950 || y_v__ >= dword_677950)
+    if (x_v__ <= kF16Zero_677B90 || y_v__ <= kF16Zero_677B90 || x_v__ >= dword_677950 || y_v__ >= dword_677950)
     {
     }
     else
@@ -1079,7 +1079,7 @@ void CarAI_78::sub_448770()
         }
     }
 
-    if (!byte_677C90 && !this->field_8)
+    if (!bIsOnGradientSlope_677C90 && !this->field_8)
     {
         if (!pBlock___)
         {
@@ -1413,7 +1413,7 @@ void CarAI_78::sub_448CE0()
                             else
                             {
                                 field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                                field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                                field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             }
                         }
                         else if (v64 <= dword_6779E4 - dword_677A08)
@@ -1427,13 +1427,13 @@ void CarAI_78::sub_448CE0()
                         else
                         {
                             field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     else if (field_10_angle != word_677CE8 || field_70)
                     {
                         field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                        field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                        field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                     }
                     else
                     {
@@ -1489,7 +1489,7 @@ void CarAI_78::sub_448CE0()
                         else
                         {
                             field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         return;
                     }
@@ -1506,7 +1506,7 @@ void CarAI_78::sub_448CE0()
                                 return;
                             }
                             field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             return;
                         }
                         field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::anticlockwise_1;
@@ -1523,7 +1523,7 @@ void CarAI_78::sub_448CE0()
                         {
                             field_0->field_58_physics = this->field_0->field_58_physics;
                             field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             return;
                         }
                         field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::anticlockwise_1;
@@ -1604,7 +1604,7 @@ void CarAI_78::sub_448CE0()
                             else
                             {
                                 field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                                field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                                field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             }
                             return;
                         }
@@ -1624,7 +1624,7 @@ void CarAI_78::sub_448CE0()
                                 return;
                             }
                             field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             return;
                         }
     
@@ -1637,7 +1637,7 @@ void CarAI_78::sub_448CE0()
                         if (field_10_angle < dword_677A08 + word_677B08)
                         {
                             field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             return;
                         }
                     }
@@ -1678,7 +1678,7 @@ void CarAI_78::sub_44A1F0()
 
     Ang16 v2 = word_677CE8;
     Ang16 v3 = word_677CE8;
-    Fix16 v6 = dword_677B90;
+    Fix16 v6 = kF16Zero_677B90;
 
     field_24_flags &= ~0x2000u;
 
@@ -1745,7 +1745,7 @@ void CarAI_78::sub_44A1F0()
                         if (v3 < v2 - word_677CE2)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             return;
                         }
 
@@ -1762,7 +1762,7 @@ void CarAI_78::sub_44A1F0()
                     if (v3 > v2 + word_677CE2)
                     {
                         this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                        this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                        this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         return;
                     }
                     break;
@@ -1836,7 +1836,7 @@ void CarAI_78::sub_44A1F0()
 
                 case car_ai_direction::south_2:
                     this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                    this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                    this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                     return;
             }
             if (field_4C_curr_direction != car_ai_direction::north_1)
@@ -1880,7 +1880,7 @@ void CarAI_78::sub_44A1F0()
                     if (v17 > dword_6779C8 && v17 < dword_6779D0)
                     {
                         this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                        this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                        this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         return;
                     }
 
@@ -1930,7 +1930,7 @@ void CarAI_78::sub_44A1F0()
                     return;
             }
             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
             return;
 
         case road_direction::left_4:
@@ -1977,7 +1977,7 @@ void CarAI_78::sub_44A1F0()
                 if (this->field_50 == 3)
                 {
                     field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                    field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                    field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                     return;
                 }
             }
@@ -2097,7 +2097,7 @@ void CarAI_78::sub_44AF00()
                         else
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     else
@@ -2114,7 +2114,7 @@ void CarAI_78::sub_44AF00()
                         else
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     break;
@@ -2128,7 +2128,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle >= dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2140,7 +2140,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle <= word_677CE8 - dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2163,7 +2163,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle <= dword_6779E4 - dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2181,7 +2181,7 @@ void CarAI_78::sub_44AF00()
                             else
                             {
                                 this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                                this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                                this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                             }
                         }
                         else
@@ -2205,7 +2205,7 @@ void CarAI_78::sub_44AF00()
                         else
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     else
@@ -2222,7 +2222,7 @@ void CarAI_78::sub_44AF00()
                         else
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     break;
@@ -2255,7 +2255,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle <= word_677ADE - dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2287,7 +2287,7 @@ void CarAI_78::sub_44AF00()
                         if (field_10_angle <= word_677CE8 - dword_677A2E && field_10_angle >= dword_6779E4)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2315,7 +2315,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle <= dword_6779E4 - dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2344,7 +2344,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle <= word_677B08 - dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2378,7 +2378,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle >= word_677ADE + dword_677A2E)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2405,7 +2405,7 @@ void CarAI_78::sub_44AF00()
                         if (this->field_10_angle >= dword_677A2E + word_677CE8)
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                         else
                         {
@@ -2433,7 +2433,7 @@ void CarAI_78::sub_44AF00()
                         else
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     else
@@ -2465,7 +2465,7 @@ void CarAI_78::sub_44AF00()
                         else
                         {
                             this->field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                            this->field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                            this->field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                         }
                     }
                     break;
@@ -2497,7 +2497,7 @@ void CarAI_78::sub_44D1D0()
         return;
     }
 
-    if (byte_677C90)
+    if (bIsOnGradientSlope_677C90)
     {
         return;
     }
@@ -2595,7 +2595,7 @@ void CarAI_78::sub_44D1D0()
         dword_677A74 = v17;
         dword_677A80 = v18;
 
-        if (v17 > dword_677B90 && v18 > dword_677B90 && v17 < dword_677950 && v18 < dword_677950)
+        if (v17 > kF16Zero_677B90 && v18 > kF16Zero_677B90 && v17 < dword_677950 && v18 < dword_677950)
         {
             gmp_block_info* block_4DFE10 =
                 gMap_0x370_6F6268->get_block_4DFE10(v17.ToInt(), v18.ToInt(), this->field_0->field_50_car_sprite->field_1C_zpos.ToInt());
@@ -2635,7 +2635,7 @@ void CarAI_78::sub_44D1D0()
     LABEL_48:
         if (v20 == v109 - 1)
         {
-            if (byte_677A94 || dword_677A8C > dword_6779C0 || field_70->field_8_car_bc_ptr->sub_43A240() == dword_677B90)
+            if (byte_677A94 || dword_677A8C > dword_6779C0 || field_70->field_8_car_bc_ptr->sub_43A240() == kF16Zero_677B90)
             {
                 field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
@@ -2789,7 +2789,7 @@ LABEL_90:
     CarAI_78* v75 = field_70->field_8_car_bc_ptr->field_5C;
     if (v75)
     {
-        if (v75->field_2A < 50u)
+        if (v75->field_2A_stopped_timer < 50u)
         {
             return;
         }
@@ -3112,7 +3112,7 @@ void CarAI_78::UpdateStateMachine_44E560()
     Ang16 v248 = word_677CE8;
     Ang16 v263 = word_677CE8;
     Ang16 v256 = word_677CE8;
-    Fix16 v241 = dword_677B90;
+    Fix16 v241 = kF16Zero_677B90;
     this->field_24_flags &= ~0x4580u;
     //Hamburger_40* v4 = field_0->field_60;
     s32 v5 = 0;
@@ -3715,7 +3715,7 @@ void CarAI_78::UpdateStateMachine_44E560()
             {
                 CarPhysics_B0* t = this->field_0->field_58_physics;
                 t->field_AD_turn_direction = car_turn_direction::none_0;
-                t->field_78_pointing_ang_rad = dword_677B90;
+                t->field_78_pointing_ang_rad = kF16Zero_677B90;
                 byte_677A5C = 1;
                 goto LABEL_186;
             }
@@ -3821,7 +3821,7 @@ LABEL_190:
         {
             CarPhysics_B0* v126 = this->field_0->field_58_physics;
             v126->field_AD_turn_direction = car_turn_direction::none_0;
-            v126->field_78_pointing_ang_rad = dword_677B90;
+            v126->field_78_pointing_ang_rad = kF16Zero_677B90;
         }
     }
 
@@ -4447,13 +4447,13 @@ void CarAI_78::sub_451980()
                     // line 1e7
                     if (field_0->field_60->field_8_maybe_path_type == 2)
                     {
-                        if (dword_677A8C == dword_677B90)
+                        if (dword_677A8C == kF16Zero_677B90)
                         {
                             field_0->sub_43A950();
                         }
                         else
                         {
-                            if (gCurrCarAI_Velocity_677B00 >= dword_677B90)
+                            if (gCurrCarAI_Velocity_677B00 >= kF16Zero_677B90)
                             {
                                 field_0->field_58_physics->sub_42ABC0();
                             }
@@ -4601,7 +4601,7 @@ void CarAI_78::sub_451980()
             }
         }
     }
-    else if (gCurrCarAI_Velocity_677B00 == dword_677B90)
+    else if (gCurrCarAI_Velocity_677B00 == kF16Zero_677B90)
     {
         if ((field_24_flags & 0x90) == 0)
         {
@@ -4689,7 +4689,7 @@ void CarAI_78::sub_452060()
     }
 
     Fix16 new_z;
-    if (byte_677C90)
+    if (bIsOnGradientSlope_677C90)
     {
         new_z = v1 + pCar->field_50_car_sprite->field_1C_zpos;
     }
@@ -4740,7 +4740,7 @@ void CarAI_78::sub_452060()
     }
 
     this->field_70 = gPurpleDoom_1_679208->FindNearestSpriteOfType_477E60(this->field_0->field_50_car_sprite, 0);
-    if (!this->field_70 || byte_677C90)
+    if (!this->field_70 || bIsOnGradientSlope_677C90)
     {
         field_0->field_50_car_sprite->set_xyz_lazy_420600(gCurrCarAI_xpos_677C38, gCurrCarAI_ypos_677C30, gCurrCarAI_zpos_677C48);
 
@@ -4758,7 +4758,7 @@ void CarAI_78::sub_452060()
 LABEL_31:
     if (!this->field_70)
     {
-        if (byte_677C90)
+        if (bIsOnGradientSlope_677C90)
         {
             Fix16 new_y_5 = v10 + field_0->field_50_car_sprite->field_14_xy.y;
             Fix16 new_x_3 = v9 + field_0->field_50_car_sprite->field_14_xy.x;
@@ -4839,7 +4839,7 @@ LABEL_31:
 
     //LABEL_62:
     byte_6771DC = 0;
-    if (byte_677C90)
+    if (bIsOnGradientSlope_677C90)
     {
         if (bCheckMovement)
         {
@@ -4881,7 +4881,7 @@ LABEL_31:
     LABEL_76:
         byte_677BBC = 0;
         this->field_24_flags &= ~0x80u;
-        if (gCurrCarAI_Velocity_677B00 == dword_677B90)
+        if (gCurrCarAI_Velocity_677B00 == kF16Zero_677B90)
         {
             this->field_5A = 0;
             this->field_24_flags |= 0x40;
@@ -4908,10 +4908,10 @@ LABEL_31:
         goto LABEL_104;
     }
 
-    if ((f70->field_1C_zpos.GetFracValue()) == dword_677B90)
+    if ((f70->field_1C_zpos.GetFracValue()) == kF16Zero_677B90)
     {
         gmp_block_info* pBlock;
-        if (byte_677C90)
+        if (bIsOnGradientSlope_677C90)
         {
             pBlock = gMap_0x370_6F6268->get_block_452980(f70->field_14_xy.x.ToInt(),
                                                          f70->field_14_xy.y.ToInt(),
@@ -4955,7 +4955,7 @@ LABEL_31:
             goto LABEL_99;
         }
     }
-    else if (byte_677C90)
+    else if (bIsOnGradientSlope_677C90)
     {
         gmp_block_info* pBlock__ =
             gMap_0x370_6F6268->get_block_452980(f70->field_14_xy.x.ToInt(), f70->field_14_xy.y.ToInt(), f70->field_1C_zpos.ToInt());
@@ -5119,8 +5119,8 @@ void CarAI_78::sub_452A20()
                 if (v3->field_10)
                 {
                     Fix16_Point v45;
-                    v45.x = Ang16::sine_40F500(word_677CE8) * dword_677B90;
-                    v45.y = (Ang16::cosine_40F520(word_677CE8) * dword_677B90);
+                    v45.x = Ang16::sine_40F500(word_677CE8) * kF16Zero_677B90;
+                    v45.y = (Ang16::cosine_40F520(word_677CE8) * kF16Zero_677B90);
                     if (dword_6779B0)
                     {
                         if (dword_6779B0 == this->field_68)
@@ -5185,10 +5185,10 @@ void CarAI_78::sub_452A20()
         }
 
         u8 v26;
-        if (field_2A)
+        if (field_2A_stopped_timer)
         {
-            v26 = (u8)field_2A <= 0x14u;
-            if ((u8)field_2A < 0x14u)
+            v26 = (u8)field_2A_stopped_timer <= 0x14u;
+            if ((u8)field_2A_stopped_timer < 0x14u)
             {
                 goto LABEL_18;
             }
@@ -5246,7 +5246,7 @@ void CarAI_78::sub_452A20()
             byte_677A5D = 0;
         }
 
-        if ((this->field_24_flags & 0x200000) != 0 && this->field_2A < 0x3Cu && gCurrCarAI_Velocity_677B00 < dword_677B58)
+        if ((this->field_24_flags & 0x200000) != 0 && this->field_2A_stopped_timer < 0x3Cu && gCurrCarAI_Velocity_677B00 < dword_677B58)
         {
             CarPhysics_B0* v30 = this->field_0->field_58_physics;
             v30->field_93_is_forward_gas_on = 1;
@@ -5300,14 +5300,14 @@ void CarAI_78::sub_452DF0()
     if (pBlock && (pBlock->field_B_slope_type & 0xFC) > 0 && (pBlock->field_B_slope_type & 0xFCu) < 0xB4 &&
         (pBlock->field_B_slope_type & 3) != 0)
     {
-        byte_677C90 = 1;
+        bIsOnGradientSlope_677C90 = true;
     }
     else
     {
         pBlock = gMap_0x370_6F6268->get_block_4DFE10(field_0->field_50_car_sprite->field_14_xy.x.ToInt(),
                                                      field_0->field_50_car_sprite->field_14_xy.y.ToInt(),
                                                      (field_0->field_50_car_sprite->field_1C_zpos.ToInt()) - 1);
-        byte_677C90 = 0;
+        bIsOnGradientSlope_677C90 = false;
     }
 
     if (pBlock)
@@ -5363,7 +5363,7 @@ void CarAI_78::sub_452DF0()
             case 0:
                 field_24_flags &= ~0x20C0u;
                 field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::none_0;
-                field_0->field_58_physics->field_78_pointing_ang_rad = dword_677B90;
+                field_0->field_58_physics->field_78_pointing_ang_rad = kF16Zero_677B90;
                 break;
 
             case 1:
@@ -5389,21 +5389,21 @@ void CarAI_78::sub_452DF0()
 
     sub_452060();
 
-    if (gCurrCarAI_Velocity_677B00 != dword_677B90)
+    if (gCurrCarAI_Velocity_677B00 != kF16Zero_677B90)
     {
         // TODO: Use dword_677B90  as Kzero
-        if (field_0->field_58_physics->field_0_vel_read_only.GetLength_2() == dword_677B90)
+        if (field_0->field_58_physics->field_0_vel_read_only.GetLength_2() == kF16Zero_677B90)
         {
-            ++field_2A;
+            ++field_2A_stopped_timer;
         }
         else
         {
-            field_2A = 0;
+            field_2A_stopped_timer = 0;
         }
     }
     else
     {
-        ++field_2A;
+        ++field_2A_stopped_timer;
     }
 
     sub_452A20();
@@ -5576,7 +5576,7 @@ void CarAI_78::sub_4539D0()
     if (f14 < f18)
     {
         this->field_14 = field_1C + f14;
-        if (field_1C < dword_677B90)
+        if (field_1C < kF16Zero_677B90)
         {
             sub_453990(this->field_18);
         }
@@ -5600,7 +5600,7 @@ void CarAI_78::sub_4539D0()
 MATCH_FUNC(0x453a40)
 void CarAI_78::sub_453A40()
 {
-    Fix16 zpos = dword_677B90;
+    Fix16 zpos = kF16Zero_677B90;
     s32 a5 = 0;
     Car_BC* v2 = this->field_0;
 
@@ -5644,7 +5644,7 @@ void CarAI_78::sub_453A40()
     }
 
     Fix16 i;
-    for (i = Ang16::Ang16_to_Fix16(sub_4F7940(&v4)); i < dword_677B90; i += dword_677C84)
+    for (i = Ang16::Ang16_to_Fix16(sub_4F7940(&v4)); i < kF16Zero_677B90; i += dword_677C84)
     {
         ;
     }
@@ -5663,7 +5663,7 @@ MATCH_FUNC(0x447650)
 void __stdcall sub_447650()
 {
     byte_677A78 = 0;
-    byte_677C90 = 0;
+    bIsOnGradientSlope_677C90 = 0;
     byte_677A5D = 1;
     byte_677B3C = 1;
     byte_677BBC = 0;
@@ -5673,17 +5673,17 @@ void __stdcall sub_447650()
     byte_677B8C = 1;
     byte_677CA8 = 0;
     byte_677C06 = 0;
-    gCurrCarAI_xpos_677C38 = dword_677B90;
-    gCurrCarAI_ypos_677C30 = dword_677B90;
-    gCurrCarAI_zpos_677C48 = dword_677B90;
-    dword_677A74 = dword_677B90;
-    dword_677A80 = dword_677B90;
-    gCurrCarAI_Velocity_677B00 = dword_677B90;
-    dword_677C9C = dword_677B90;
-    dword_677A8C = dword_677B90;
-    dword_6779F0 = dword_677B90;
-    dword_6779F4 = dword_677B90;
-    dword_6779F8 = dword_677B90;
+    gCurrCarAI_xpos_677C38 = kF16Zero_677B90;
+    gCurrCarAI_ypos_677C30 = kF16Zero_677B90;
+    gCurrCarAI_zpos_677C48 = kF16Zero_677B90;
+    dword_677A74 = kF16Zero_677B90;
+    dword_677A80 = kF16Zero_677B90;
+    gCurrCarAI_Velocity_677B00 = kF16Zero_677B90;
+    dword_677C9C = kF16Zero_677B90;
+    dword_677A8C = kF16Zero_677B90;
+    dword_6779F0 = kF16Zero_677B90;
+    dword_6779F4 = kF16Zero_677B90;
+    dword_6779F8 = kF16Zero_677B90;
     dword_677C88 = 1;
     dword_6779B0 = 0;
 }
@@ -5741,7 +5741,7 @@ void CarAI_78::PoolAllocate()
     this->field_9 = 0;
     this->field_A = 0;
     this->field_10_angle = word_677CE8;
-    this->field_14 = dword_677B90;
+    this->field_14 = kF16Zero_677B90;
     this->field_18 = dword_677CB4;
     this->field_1C = dword_6779A4;
     this->field_20 = 0;
@@ -5754,9 +5754,9 @@ void CarAI_78::PoolAllocate()
     this->field_2D = 0;
     this->field_2E = 0;
     this->field_2F = 0;
-    this->field_5C = dword_677B90;
-    this->field_60 = dword_677B90;
-    this->field_64 = dword_677B90;
+    this->field_5C = kF16Zero_677B90;
+    this->field_60 = kF16Zero_677B90;
+    this->field_64 = kF16Zero_677B90;
     this->field_68 = 0;
     this->field_6C = 0;
     this->field_34 = 0;
@@ -5769,7 +5769,7 @@ void CarAI_78::PoolAllocate()
     this->field_70 = 0;
     this->field_74 = dword_6779D4;
     this->field_54 = 0;
-    this->field_2A = 0;
+    this->field_2A_stopped_timer = 0;
     this->field_2B = 0;
     this->field_2C = 0;
     this->field_24_flags &= ~0x3C0000u;
@@ -5789,7 +5789,7 @@ CarAI_78::CarAI_78()
     this->field_A = 0;
     this->mpNext = 0;
     this->field_10_angle = word_677CE8;
-    this->field_14 = dword_677B90;
+    this->field_14 = kF16Zero_677B90;
     this->field_18 = dword_677CB4;
     this->field_1C = dword_6779A4;
     this->field_20 = 0;
@@ -5802,9 +5802,9 @@ CarAI_78::CarAI_78()
     this->field_2D = 0;
     this->field_2E = 0;
     this->field_2F = 0;
-    this->field_5C = dword_677B90;
-    this->field_60 = dword_677B90;
-    this->field_64 = dword_677B90;
+    this->field_5C = kF16Zero_677B90;
+    this->field_60 = kF16Zero_677B90;
+    this->field_64 = kF16Zero_677B90;
     this->field_68 = 0;
     this->field_6C = 0;
     this->field_34 = 0;
@@ -5815,9 +5815,9 @@ CarAI_78::CarAI_78()
     this->field_48 = 0;
     this->field_4C_curr_direction = car_ai_direction::none_0;
     this->field_70 = 0;
-    this->field_74 = dword_677B90;
+    this->field_74 = kF16Zero_677B90;
     this->field_54 = 0;
-    this->field_2A = 0;
+    this->field_2A_stopped_timer = 0;
     this->field_2B = 0;
     this->field_2C = 0;
     this->field_5A = 0;

--- a/Source/CarAI_78.cpp
+++ b/Source/CarAI_78.cpp
@@ -93,6 +93,19 @@ DEFINE_GLOBAL_INIT(Ang16, word_677A38, Ang16(180), 0x677A38);
 EXTERN_GLOBAL(u16, word_677CFC);
 EXTERN_GLOBAL(u8, byte_6771DC);
 
+// TODO: move
+inline void __stdcall RotateAndTranslatePoint_42A720(Fix16& pInX,
+                                                         Fix16& pInY,
+                                                         Ang16& pRotAng,
+                                                         Fix16& pTransX,
+                                                         Fix16& pTransY,
+                                                         Fix16& pRotTransX,
+                                                         Fix16& pRotTransY)
+{
+    pRotTransX = (((pInX - pTransX) * Ang16::cosine_40F520(pRotAng)) + ((pInY - pTransY) * Ang16::sine_40F500(pRotAng)));
+    pRotTransY = ((-(pInX - pTransX) * Ang16::sine_40F500(pRotAng)) + ((pInY - pTransY) * Ang16::cosine_40F520(pRotAng)));
+}
+
 MATCH_FUNC(0x4476f0)
 void CarAI_78::MakeAgressiveSirensAndLights_4476F0()
 {
@@ -1250,11 +1263,11 @@ void CarAI_78::sub_448CE0()
                     }
                     else if (field_44_target_direction == car_ai_target_direction::westwards_4)    // OBS: swapped IF order with the one below
                     {
-                        field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                        field_0->field_58_physics->TurnAntiClockwise_42AB90();
                     }
                     else if (field_44_target_direction == car_ai_target_direction::eastwards_3)
                     {
-                        field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                        field_0->field_58_physics->TurnClockwise_42ABA0();
                     }
                     
                     //return;
@@ -1298,12 +1311,12 @@ void CarAI_78::sub_448CE0()
                                     }
                                     else
                                     {
-                                        field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                                        field_0->field_58_physics->TurnClockwise_42ABA0();
                                     }
                                 }
                                 else
                                 {
-                                    field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                                    field_0->field_58_physics->TurnAntiClockwise_42AB90();
                                 }
                                 
                             }
@@ -1317,12 +1330,12 @@ void CarAI_78::sub_448CE0()
                                     }
                                     else
                                     {
-                                        field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                                        field_0->field_58_physics->TurnAntiClockwise_42AB90();
                                     }
                                 }
                                 else
                                 {
-                                    field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                                    field_0->field_58_physics->TurnClockwise_42ABA0();
                                 }
                             }
                         }
@@ -1332,11 +1345,11 @@ void CarAI_78::sub_448CE0()
                         this->field_24_flags &= ~0x12000u;
                         if (field_10_angle > word_677ADE)
                         {
-                            field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                            field_0->field_58_physics->TurnClockwise_42ABA0();
                         }
                         else
                         {
-                            field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                            field_0->field_58_physics->TurnAntiClockwise_42AB90();
                         }
                     }
                 }
@@ -1351,11 +1364,11 @@ void CarAI_78::sub_448CE0()
                     {
                         if (field_44_target_direction == car_ai_target_direction::westwards_4)
                         {
-                            field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                            field_0->field_58_physics->TurnClockwise_42ABA0();
                         }
                         else if (field_44_target_direction == car_ai_target_direction::eastwards_3)
                         {
-                            field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                            field_0->field_58_physics->TurnAntiClockwise_42AB90();
                         }
                     }
                     else
@@ -4554,14 +4567,14 @@ void CarAI_78::sub_451980()
                                         case 3:
                                         case 6:
                                         case 8:
-                                            field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                                            field_0->field_58_physics->TurnAntiClockwise_42AB90();
                                             byte_677BBC = 0;
                                             byte_677A5D = 0;
                                             return;
                                         case 4:
                                         case 7:
                                         case 9:
-                                            field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                                            field_0->field_58_physics->TurnClockwise_42ABA0();
                                             byte_677BBC = 0;
                                             byte_677A5D = 0;
                                             return;
@@ -4585,11 +4598,11 @@ void CarAI_78::sub_451980()
 
                                 if (v26 < v27)
                                 {
-                                    field_0->field_58_physics->TurnDirectionMinus_42ABA0();
+                                    field_0->field_58_physics->TurnClockwise_42ABA0();
                                 }
                                 else
                                 {
-                                    field_0->field_58_physics->TurnDirectionPlus_42AB90();
+                                    field_0->field_58_physics->TurnAntiClockwise_42AB90();
                                 }
 
                                 byte_677BBC = 0;
@@ -5091,39 +5104,37 @@ LABEL_104:
     }
 }
 
+// https://decomp.me/scratch/zCa7m
 WIP_FUNC(0x452a20)
 void CarAI_78::sub_452A20()
 {
     WIP_IMPLEMENTED;
+    Fix16_Point v45;
 
-    if ((field_24_flags & 0x1000) != 0)
+    if (field_24_bf.b12)
     {
-        // goto LABEL_41;
-
-        if (this->field_68->field_88_despawn_status == 5)
+        if (field_68->IsDespawning_4215B0())
         {
             return;
         }
 
-        if (this->field_3C == 1)
+        if (field_3C == 1)
         {
-            this->field_3C = 0;
-            this->field_24_flags &= 0x3F;
+            field_3C = 0;
+            field_24_bf.b6 = false;
+            field_24_bf.b7 = false;
         }
 
         if (byte_677BBC)
         {
-            Hamburger_40* v3 = this->field_0->field_60;
-            if (v3)
+            if (field_0->field_60)
             {
-                if (v3->field_10)
+                if (field_0->field_60->field_10)
                 {
-                    Fix16_Point v45;
-                    v45.x = Ang16::sine_40F500(word_677CE8) * kF16Zero_677B90;
-                    v45.y = (Ang16::cosine_40F520(word_677CE8) * kF16Zero_677B90);
+                    v45.FromPolar_41E210(kF16Zero_677B90, word_677CE8);
                     if (dword_6779B0)
                     {
-                        if (dword_6779B0 == this->field_68)
+                        if (dword_6779B0 == field_68)
                         {
                             dword_6779B0->AccumulateDamage_43DA90(500, &v45);
                         }
@@ -5131,140 +5142,116 @@ void CarAI_78::sub_452A20()
                 }
             }
         }
-        this->field_24_flags &= ~0x30100u;
+        field_24_flags &= ~0x30100u;
         byte_677BBC = 0;
-        if (this->field_0->field_60)
+        if (field_0->field_60)
         {
-            this->field_0->field_60->field_2E = 0;
-            this->field_0->field_60->field_2A = 0;
-            this->field_0->field_60->field_2C = 0;
+            if (field_68->field_60)
+            {
+                field_0->field_60->field_2E = 0;
+                field_0->field_60->field_2A = 0;
+                field_0->field_60->field_2C = 0;
+            }
+            else
+            {
+                field_0->field_60->field_2E = 0;
+                field_0->field_60->field_2A = 0;
+                field_0->field_60->field_2C = 0;
+            }
         }
 
-        Ang16 v35 = -this->field_10_angle;
+        Fix16 rotX;
+        Fix16 rotY;
+        RotateAndTranslatePoint_42A720(field_68->field_50_car_sprite->field_14_xy.x,
+                                       field_68->field_50_car_sprite->field_14_xy.y,
+                                       -field_10_angle,
+                                       gCurrCarAI_xpos_677C38,
+                                       gCurrCarAI_ypos_677C30,
+                                       rotX,
+                                       rotY);
 
-        Fix16 p_y = field_68->field_50_car_sprite->field_14_xy.y;
+        Fix16 v21 = field_0->field_50_car_sprite->field_14_xy.x + rotX;
 
-        Fix16 p_field_14_xy = field_68->field_50_car_sprite->field_14_xy.x;
-
-        Fix16 rotX = (((p_field_14_xy - gCurrCarAI_xpos_677C38) * Ang16::cosine_40F520(v35)) + ((p_y - gCurrCarAI_ypos_677C30) * Ang16::sine_40F500(v35)));
-        Fix16 rotY = ((-(p_field_14_xy - gCurrCarAI_xpos_677C38) * Ang16::sine_40F500(v35)) + ((p_y - gCurrCarAI_ypos_677C30) * Ang16::cosine_40F520(v35)));
-
-        Fix16 v21 = this->field_0->field_50_car_sprite->field_14_xy.x + rotX;
-
-        Ped* pDriver = this->field_68->field_54_driver;
-
-        CarPhysics_B0* v29;
+        Ped* pDriver = field_68->field_54_driver;
 
         if (pDriver && pDriver->IsField238_45EDE0(2))
         {
-            if ((this->field_24_flags & 0x200000) == 0)
+            if (field_24_bf.b21 == false)
             {
-                CarPhysics_B0* pPhysics = this->field_0->field_58_physics;
-                pPhysics->field_91_is_foot_brake_on = 0;
-                pPhysics->field_93_is_forward_gas_on = 0;
-                pPhysics->field_94_is_backward_gas_on = 0;
-                pPhysics->field_95 = 0;
+                field_0->field_58_physics->sub_42AC00();
                 byte_677A5D = 0;
                 return;
             }
             goto LABEL_18;
         }
-
-        if ((this->field_24_flags & 0x200000) != 0)
+        else if (field_24_bf.b21 == false)
         {
-        LABEL_18:
-            if (v21 <= this->field_0->field_50_car_sprite->field_14_xy.x)
+            u8 v26;
+            if (field_2A_stopped_timer)
             {
-                field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::anticlockwise_1;
+                v26 = field_2A_stopped_timer <= 20;
+                if (field_2A_stopped_timer < 20)
+                {
+                    goto LABEL_18;
+                }
             }
             else
             {
-                field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::clockwise_m1;
+                v26 = 1;
             }
-            goto LABEL_29;
-        }
 
-        u8 v26;
-        if (field_2A_stopped_timer)
-        {
-            v26 = (u8)field_2A_stopped_timer <= 0x14u;
-            if ((u8)field_2A_stopped_timer < 0x14u)
+            if (v26)
             {
-                goto LABEL_18;
+                field_0->field_58_physics->sub_42AC00();
+                return;
+            }
+
+            if (v21 > field_0->field_50_car_sprite->field_14_xy.x)
+            {
+                field_0->field_58_physics->TurnAntiClockwise_42AB90();
+            }
+            else
+            {
+                field_0->field_58_physics->TurnClockwise_42ABA0();
             }
         }
         else
         {
-            v26 = 1;
+        LABEL_18:
+            if (v21 > field_0->field_50_car_sprite->field_14_xy.x)
+            {
+                field_0->field_58_physics->TurnClockwise_42ABA0();
+            }
+            else
+            {
+                field_0->field_58_physics->TurnAntiClockwise_42AB90();
+            }
         }
 
-        if (v26)
+        if (field_70 && field_70->field_8_car_bc_ptr == field_68)
         {
-            CarPhysics_B0* v32 = this->field_0->field_58_physics;
-            v32->field_91_is_foot_brake_on = 0;
-            v32->field_93_is_forward_gas_on = 0;
-            v32->field_94_is_backward_gas_on = 0;
-            v32->field_95 = 0;
-            return;
-        }
-
-        if (v21 <= this->field_0->field_50_car_sprite->field_14_xy.x.mValue)
-        {
-            field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::clockwise_m1;
+            field_0->field_58_physics->sub_421210();
         }
         else
         {
-            field_0->field_58_physics->field_AD_turn_direction = car_turn_direction::anticlockwise_1;
+            field_0->field_58_physics->sub_42AC00();
+        }
+        byte_677A5D = 0;
+
+        if ((field_24_flags & 0x200000) != 0 && field_2A_stopped_timer < 60 && gCurrCarAI_Velocity_677B00 < dword_677B58)
+        {
+            field_0->field_58_physics->sub_421210();
         }
 
-    LABEL_29:
-        if (!field_70)
+        if (!field_54)
         {
-            CarPhysics_B0* v29 = this->field_0->field_58_physics;
-            v29->field_91_is_foot_brake_on = 0;
-            v29->field_93_is_forward_gas_on = 0;
-            v29->field_94_is_backward_gas_on = 0;
-            v29->field_95 = 0;
-            byte_677A5D = 0;
-        }
-        else if (field_70->field_8_car_bc_ptr != field_68)
-        {
-            CarPhysics_B0* v29 = this->field_0->field_58_physics;
-            v29->field_91_is_foot_brake_on = 0;
-            v29->field_93_is_forward_gas_on = 0;
-            v29->field_94_is_backward_gas_on = 0;
-            v29->field_95 = 0;
-            byte_677A5D = 0;
-        }
-        else
-        {
-            v29 = this->field_0->field_58_physics;
-            v29->field_93_is_forward_gas_on = 1;
-            v29->field_91_is_foot_brake_on = 0;
-            v29->field_94_is_backward_gas_on = 0;
-            v29->field_95 = 0;
-            byte_677A5D = 0;
-        }
-
-        if ((this->field_24_flags & 0x200000) != 0 && this->field_2A_stopped_timer < 0x3Cu && gCurrCarAI_Velocity_677B00 < dword_677B58)
-        {
-            CarPhysics_B0* v30 = this->field_0->field_58_physics;
-            v30->field_93_is_forward_gas_on = 1;
-            v30->field_91_is_foot_brake_on = 0;
-            v30->field_94_is_backward_gas_on = 0;
-            v30->field_95 = 0;
-        }
-
-        if (!this->field_54)
-        {
-            this->field_54 = 4;
+            field_54 = 4;
         }
     }
 
-    //LABEL_41:
-    if (field_54)
+    if (field_54 > 0)
     {
-        this->field_54--;
+        field_54--;
     }
 }
 

--- a/Source/CarAI_78.hpp
+++ b/Source/CarAI_78.hpp
@@ -98,7 +98,7 @@ class CarAI_78
 
     char_type field_28_junc_idx;
     char_type field_29;
-    char_type field_2A;
+    char_type field_2A_stopped_timer;
     u8 field_2B;
     char_type field_2C;
     char_type field_2D;

--- a/Source/CarAI_78.hpp
+++ b/Source/CarAI_78.hpp
@@ -116,7 +116,7 @@ class CarAI_78
     s32 field_48;
     s32 field_4C_curr_direction;
     s32 field_50;
-    s16 field_54;
+    u16 field_54;
     s16 field_56;
     s16 field_58;
     s16 field_5A;

--- a/Source/CarPhysics_B0.hpp
+++ b/Source/CarPhysics_B0.hpp
@@ -314,15 +314,15 @@ class CarPhysics_B0
     }
 
     // FUNCTION: 96f 0x42ABA0
-    void TurnDirectionMinus_42ABA0()
+    void TurnClockwise_42ABA0()
     {
-        field_AD_turn_direction = -1;
+        field_AD_turn_direction = car_turn_direction::clockwise_m1;
     }
 
     // FUNCTION: 96f 0x42AB90
-    void TurnDirectionPlus_42AB90()
+    void TurnAntiClockwise_42AB90()
     {
-        field_AD_turn_direction = 1;
+        field_AD_turn_direction = car_turn_direction::anticlockwise_1;
     }
 
     void SetGoStraight_42ABB0()

--- a/Source/CarPhysics_B0.hpp
+++ b/Source/CarPhysics_B0.hpp
@@ -24,7 +24,7 @@ EXTERN_GLOBAL(Fix16, dword_6FE348);
 EXTERN_GLOBAL(Fix16, dword_677794);
 EXTERN_GLOBAL(Fix16_Point, stru_6FDF50);
 EXTERN_GLOBAL(Fix16, dword_6FE0B0);
-EXTERN_GLOBAL(Fix16, dword_677B90);
+EXTERN_GLOBAL(Fix16, kF16Zero_677B90);
 
 EXPORT Fix16_Point __stdcall ComputeLineLineIntersection_55F3B0(Fix16 a2,
                                                                 Fix16 a3,
@@ -328,7 +328,7 @@ class CarPhysics_B0
     void SetGoStraight_42ABB0()
     {
         field_AD_turn_direction = 0;
-        field_78_pointing_ang_rad = dword_677B90;
+        field_78_pointing_ang_rad = kF16Zero_677B90;
     }
 
     EXPORT Fix16 vec_len_552DE0(); // Char_B4.cpp func

--- a/Source/Car_BC.cpp
+++ b/Source/Car_BC.cpp
@@ -5273,7 +5273,7 @@ void Car_BC::sub_442810()
 
     field_50_car_sprite->set_num_40F7B0(15);
 
-    if (!sub_43A230() && !IsMaxDamage_40F890() && !sub_4214B0() && !sub_4215B0())
+    if (!sub_43A230() && !IsMaxDamage_40F890() && !sub_4214B0() && !IsDespawning_4215B0())
     {
         stru_67727C.PruneNonCollidingSprites_5A7240(field_50_car_sprite);
         Sprite* v4 =

--- a/Source/Car_BC.hpp
+++ b/Source/Car_BC.hpp
@@ -899,9 +899,9 @@ class Car_BC
     }
 
     // FUNCTION: 96f 0x4215b0
-    bool sub_4215B0()
+    bool IsDespawning_4215B0()
     {
-        return this->field_88_despawn_status == 5;
+        return field_88_despawn_status == 5;
     }
 
     bool sub_421620()

--- a/Source/Cranes.cpp
+++ b/Source/Cranes.cpp
@@ -359,11 +359,11 @@ MATCH_FUNC(0x47f350)
 bool Crane_15C::sub_47F350()
 {
     Car_BC* pCar1 = field_70->AsCar_40FEB0();
-    if (!pCar1->sub_4215B0())
+    if (!pCar1->IsDespawning_4215B0())
     {
         Sprite *sp = field_6C;
         Car_BC* pCar2 = sp->AsCar_40FEB0();
-        if (!(pCar2->sub_4215B0() || field_FC != sp->field_14_xy.x || field_100 != sp->field_14_xy.y ||
+        if (!(pCar2->IsDespawning_4215B0() || field_FC != sp->field_14_xy.x || field_100 != sp->field_14_xy.y ||
             field_104 != sp->field_1C_zpos || field_108 != Ang16::Ang16_to_Fix16(sp->field_0)))
         {
             return true;
@@ -377,7 +377,7 @@ MATCH_FUNC(0x47f3d0)
 bool Crane_15C::sub_47F3D0()
 {
     Car_BC* v2 = field_68->AsCar_40FEB0();
-    if (!v2->sub_4215B0() && this->field_E0 == field_68->field_14_xy.x && this->field_E4 == field_68->field_14_xy.y &&
+    if (!v2->IsDespawning_4215B0() && this->field_E0 == field_68->field_14_xy.x && this->field_E4 == field_68->field_14_xy.y &&
         this->field_E8 == field_68->field_1C_zpos && this->field_EC == Ang16::Ang16_to_Fix16(field_68->field_0) && !v2->field_54_driver &&
         v2->sub_441A40())
     {
@@ -390,7 +390,7 @@ MATCH_FUNC(0x47f450)
 bool Crane_15C::sub_47F450()
 {
     Car_BC* pCar = field_64->AsCar_40FEB0();
-    if (!pCar->sub_4215B0() && this->field_C4.x == field_64->field_14_xy.x && this->field_C4.y == field_64->field_14_xy.y &&
+    if (!pCar->IsDespawning_4215B0() && this->field_C4.x == field_64->field_14_xy.x && this->field_C4.y == field_64->field_14_xy.y &&
         this->field_CC == field_64->field_1C_zpos && this->field_D0 == Ang16::Ang16_to_Fix16(field_64->field_0))
     {
         return pCar->field_0_qq.FirstSpriteOfType_5A6CA0(sprite_types_enum::car) ? false : true;
@@ -556,7 +556,7 @@ void Crane_15C::PickUpCar_47F930(Car_BC* pCar)
 {
     WIP_IMPLEMENTED;
 
-    if (!pCar->sub_4215B0() && !field_28_strct4.TagSpriteWithRng_5A6C10(pCar->field_50_car_sprite))
+    if (!pCar->IsDespawning_4215B0() && !field_28_strct4.TagSpriteWithRng_5A6C10(pCar->field_50_car_sprite))
     {
         if (pCar->Is_TRUKTRNS_447EC0())
         {

--- a/Source/ImGuiDebug.cpp
+++ b/Source/ImGuiDebug.cpp
@@ -62,6 +62,7 @@ EXTERN_GLOBAL_ARRAY(wchar_t, tmpBuff_67BD9C, 640);
 
 Object_2C* spawned_obj = NULL;
 Car_BC* pNewCar = NULL;
+char TmpBitSetChar[50];
 
 void wchar_to_char(wchar_t* wchar, char* out, u8 size)
 {
@@ -998,6 +999,20 @@ void BootMap(char* mapName, char* styName, char* scrName)
     }
 }
 
+void ConvertBitSetIntoString(char* pOut, u8 max_width, s32 bitset, u8 max_num_bits)
+{
+    for (u8 i = 0; i < max_num_bits; i++, pOut++)
+    {
+        *pOut = ( (bitset >> i) & 1 ) ? '1' : '0';
+        if (i > 0 && ((i+1) % max_width) == 0)
+        {
+            pOut++;
+            *pOut = '\n';
+        }
+    }
+    *pOut = 0;
+}
+
 void CC ImGuiDebugDraw()
 {
     HookManagement::HooksDebug();
@@ -1696,6 +1711,7 @@ void CC ImGuiDebugDraw()
                             pAI_Iter->field_54);
                     DisplayWideTextAtSprite(tmpBuff_67BD9C, pCarIter->field_50_car_sprite, 0, 0);
                     */
+                    /*
                     if (pCarIter->field_58_physics)
                     {
                         swprintf(tmpBuff_67BD9C, L"%d", 
@@ -1708,6 +1724,19 @@ void CC ImGuiDebugDraw()
                     {
                         swprintf(tmpBuff_67BD9C, L"Ham C: %d", pCarIter->field_60->field_C);
                         DisplayWideTextAtSprite(tmpBuff_67BD9C, pCarIter->field_50_car_sprite, 0, -15);
+                    }
+                    */
+                    /*
+                    if (pCarIter)
+                    {
+                        ConvertBitSetIntoString(TmpBitSetChar, 8, pAI_Iter->field_24_flags, 8 * sizeof(pAI_Iter->field_24_flags)); // TODO: u8 bitset
+                        DisplayTextAtSprite(TmpBitSetChar, pCarIter->field_50_car_sprite, 0, 0);
+                    }
+                    */
+                    if (pAI_Iter)
+                    {
+                        swprintf(tmpBuff_67BD9C, L"%d", pAI_Iter->field_54);
+                        DisplayWideTextAtSprite(tmpBuff_67BD9C, pCarIter->field_50_car_sprite, 0, 0);
                     }
                     num_AI_count++;
                 }

--- a/Source/Kfc_1E0.cpp
+++ b/Source/Kfc_1E0.cpp
@@ -128,7 +128,7 @@ void Kfc_30::CleanupExpiredEntities_5CC1C0()
 
     if (this->field_24 == 1)
     {
-        if (this->field_0_car && !field_0_car->sub_4215B0() && !field_0_car->IsMaxDamage_40F890())
+        if (this->field_0_car && !field_0_car->IsDespawning_4215B0() && !field_0_car->IsMaxDamage_40F890())
         {
             if (field_0_car->Get_F76_4A9AD0() > this->field_1A)
             {


### PR DESCRIPTION
Improve CarAI_78::sub_452A20
Improve CarAI_78::sub_452DF0

Car AI renames:

gCurrCarAI_xpos_677C38
gCurrCarAI_ypos_677C30
gCurrCarAI_zpos_677C48
gF16fOne_677B94
gCurrCarAI_Velocity_677B00
bIsOnGradientSlope_677C90

field_2A_stopped_timer