### PR TITLE
Fix annoying crash in car collisions

### DIFF
--- a/Source/Fix16_Point.cpp
+++ b/Source/Fix16_Point.cpp
@@ -43,7 +43,7 @@ Fix16_Point Fix16_Point::NormalizeSafe_442AD0()
     }
     else
     {
-        return *this / length;
+        return Fix16_Point(x, y) / length; // TODO: *this / length;
     }
 }
 

--- a/Source/ImGuiDebug.cpp
+++ b/Source/ImGuiDebug.cpp
@@ -37,6 +37,7 @@
 #include "text_0x14.hpp"
 #include "sound_obj.hpp"
 #include "root_sound.hpp"
+#include "Rozza_C88.hpp"
 #include "ExplodingScore_100.hpp"
 #include "CarAI_78.hpp"
 #include <direct.h>
@@ -60,6 +61,8 @@ EXTERN_GLOBAL(u8, byte_6FEB48);
 EXTERN_GLOBAL(Fix16_Point, stru_6F6484);
 
 EXTERN_GLOBAL_ARRAY(wchar_t, tmpBuff_67BD9C, 640);
+
+EXTERN_GLOBAL(Fix16_Point, CollisionIntersectionPoint_6FE1A0);
 
 Object_2C* spawned_obj = NULL;
 Car_BC* pNewCar = NULL;
@@ -951,6 +954,7 @@ static void DrawHookList(char* filter, std::vector<FuncData>& funcs, TChangeHook
     u32 i;
 
     ImGui::InputText("Filter", filter, 256);
+    /*
     if (ImGui::Button("Toggle all"))
     {
         for (i = 0; i < funcs.size(); i++)
@@ -958,6 +962,20 @@ static void DrawHookList(char* filter, std::vector<FuncData>& funcs, TChangeHook
             FuncData& d = funcs[i];
             d.hooked = !d.hooked;
             pChangeHookFn(d.funcName, d.ogAddr, d.hooked);
+        }
+    }
+    */
+
+    if (ImGui::Button("Toggle all listed"))
+    {
+        for (i = 0; i < funcs.size(); i++)
+        {
+            FuncData& d = funcs[i];
+            if (filter[0] == 0 || StrStrIA(d.funcName, filter))
+            {
+                d.hooked = !d.hooked;
+                pChangeHookFn(d.funcName, d.ogAddr, d.hooked);
+            }
         }
     }
 
@@ -2875,6 +2893,48 @@ void CC ImGuiDebugDraw()
             }
             ImGui::TreePop();
         }
+
+        if (ImGui::TreeNode("Car Physics Debug"))
+        {
+            if (ImGui::TreeNode("Show collision point"))
+            {
+                if (CollisionIntersectionPoint_6FE1A0.x > Fix16(0)
+                    && CollisionIntersectionPoint_6FE1A0.y > Fix16(0))
+                {
+                    DisplayWideTextAtXYZ(L"E", 
+                        CollisionIntersectionPoint_6FE1A0.x,
+                        CollisionIntersectionPoint_6FE1A0.y,
+                        Fix16(3));
+                }
+                ImGui::TreePop();
+            }
+            
+            if (&gRozza_679188 && ImGui::TreeNode("Show rozza sprite"))
+            {
+                ImGui::Value("Type", gRozza_679188.field_0_type);
+                if (gRozza_679188.field_20_pSprite)
+                {
+                    if (gRozza_679188.field_20_pSprite->AsCharB4_40FEA0())
+                    {
+                        PointArrowToEntity(gRozza_679188.field_20_pSprite->field_8_char_b4_ptr->field_7C_pPed, 0, 0);
+                    }
+                    else if (gRozza_679188.field_20_pSprite->AsCar_40FEB0())
+                    {
+                        PointArrowToEntity(0, gRozza_679188.field_20_pSprite->field_8_car_bc_ptr, 0);
+                    }
+                    else if (gRozza_679188.field_20_pSprite->As2C_40FEC0())
+                    {
+                        PointArrowToEntity(0, 0, gRozza_679188.field_20_pSprite->field_8_object_2C_ptr);
+                    }
+                }
+            }
+            else
+            {
+                ClearGlobalArrow();
+            }
+            ImGui::TreePop();
+        }
+            
 
         // Put in-game debug stuff here
 

--- a/Source/Object_5C.cpp
+++ b/Source/Object_5C.cpp
@@ -1380,17 +1380,17 @@ char Object_2C::ShouldCollideWithSprite_525370(Sprite* pSprite)
 
     switch (this->field_18_model)
     {
-        case 122:
+        case objects::pedestrian_crossing_marker_122:
             if (!pSprite)
             {
                 return 0;
             }
             return ShouldStopAtTrafficLight_525290(pSprite);
 
-        case 139:
+        case objects::conveyor_139:
             return 0;
 
-        case 169:
+        case objects::door_unknown_169:
             if (pSprite)
             {
                 return gDoor_4D4_67BD2C->CheckDoorAccess_49D3C0(pSprite, this->field_26_varrok_idx);
@@ -1400,7 +1400,7 @@ char Object_2C::ShouldCollideWithSprite_525370(Sprite* pSprite)
                 return byte_6F8EDC;
             }
 
-        case 294:
+        case objects::tunnel_blocker_294:
             if (pSprite)
             {
                 Car_BC* pCar = pSprite->AsCar_40FEB0();
@@ -1498,8 +1498,8 @@ EXPORT void Object_2C::CheckCollisionForModel_139_And_141_525AE0()
 {
     switch (field_18_model)
     {
-        case 139:
-        case 141:
+        case objects::conveyor_139:
+        case objects::destructor_141:
             gPurpleDoom_1_679208->CheckAndHandleCollisionInStrips_477BD0(field_4);
             gPurpleDoom_2_67920C->CheckAndHandleCollisionInStrips_477BD0(field_4);
             break;


### PR DESCRIPTION
Replace by "Toggle all listed" in hook debug (better for toggling only a set of funcs at once)
Fix annoying occasional crash for car collisions