### PR TITLE
fix: invoke Wine builds without shell concatenation

### DIFF
--- a/build.py
+++ b/build.py
@@ -189,9 +189,8 @@ def get_vc6_env():
         include2 = as_wine_path(include2)
         include3 = as_wine_path(include3)
 
-        # escape ";"
-        path = fr'{path1}\;{path2}\;{path3}'
-        include = fr'{include1}\;{include2}\;{include3};'
+        path = f'{path1};{path2};{path3}'
+        include = f'{include1};{include2};{include3};'
 
 
     vc6_cmds = list()
@@ -200,6 +199,16 @@ def get_vc6_env():
     vc6_cmds.append(path)
 
     return vc6_cmds
+
+def get_wine_env(lib: str, include: str, path: str):
+    env = os.environ.copy()
+    env.update({
+        "WINEDEBUG": "-all",
+        "WINEPATH": path,
+        "LIB": lib,
+        "INCLUDE": include,
+    })
+    return env
 
 def convert_path(strPath):
     if os.name == "posix":
@@ -236,21 +245,16 @@ def build_single_cpp(cpp_file: str):
     if linux_or_mac:
         cl_args = f"@{as_wine_path(rsp_path)}"
         build_dir = as_wine_path(BUILD_DIRECTORY)
-        command = (
-            f"WINEDEBUG=-all "
-            f"export WINEPATH={path} "
-            f"export LIB={lib} "
-            f"export INCLUDE={include} "
-            f"wine cmd /c \"cd {build_dir} && cl.exe {cl_args}\""
-        )
+        windows_command = f"cd {build_dir} && cl.exe {cl_args}"
+        command = ["wine", "cmd", "/c", windows_command]
         print(f"Running command: {command}")
         p1 = subprocess.Popen(
             command,
             cwd=BUILD_DIRECTORY,
+            env=get_wine_env(lib, include, path),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            text=True,
-            shell=True
+            text=True
         )
     else:  # Windows
         cl_args = f"@{rsp_path}"
@@ -285,20 +289,16 @@ def build_cmake(reccmp : bool, core_count_to_use : int):
 
     if platform.system() in ("Linux", "Darwin"):
         build_dir = as_wine_path(BUILD_DIRECTORY)
-        command = (
-            f"WINEDEBUG=-all "
-            f"export WINEPATH={path} "
-            f"export LIB={lib} "
-            f"export INCLUDE={include} "
-            f"wine cmd /c \"cd {build_dir} && {get_build_cmds(reccmp, core_count_to_use)[0]} && {get_build_cmds(reccmp, core_count_to_use)[1]}\""
-        )
+        build_commands = get_build_cmds(reccmp, core_count_to_use)
+        windows_command = f"cd {build_dir} && {build_commands[0]} && {build_commands[1]}"
+        command = ["wine", "cmd", "/c", windows_command]
         p1 = subprocess.Popen(
             command,
             cwd=BUILD_DIRECTORY,
+            env=get_wine_env(lib, include, path),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            text=True,
-            shell=True
+            text=True
         )
     else:  # Windows
         p1 = subprocess.Popen(

--- a/build.py
+++ b/build.py
@@ -132,9 +132,11 @@ def main():
         sys.exit(returncode)
     
     if args.reccmp:
-        python = sys.executable # should be the python venv
-        subprocess.run(f"{python} reccmp/generate.py", cwd=CURRENT_DIRECTORY, shell=True)
-        sys.exit(0)
+        result = subprocess.run(
+            [sys.executable, "reccmp/generate.py"],
+            cwd=CURRENT_DIRECTORY,
+        )
+        sys.exit(result.returncode)
 
     if not args.single_cpp:
         ok = verify()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -51,6 +51,24 @@ class PosixWineInvocationTests(unittest.TestCase):
         self.assertEqual(path.count(";"), 2)
         self.assertTrue(lib.startswith("Z:"))
 
+    @mock.patch.object(build, "check_duplicated_globals", return_value=True)
+    @mock.patch.object(build, "build_cmake", return_value=0)
+    @mock.patch.object(build.subprocess, "run")
+    def test_reccmp_generation_failure_is_returned_to_caller(
+        self, run, _build_cmake, _check_globals
+    ):
+        run.return_value = mock.Mock(returncode=7)
+
+        with mock.patch.object(build.sys, "argv", ["build.py", "--reccmp"]):
+            with self.assertRaises(SystemExit) as exit_context:
+                build.main()
+
+        self.assertEqual(exit_context.exception.code, 7)
+        run.assert_called_once_with(
+            [build.sys.executable, "reccmp/generate.py"],
+            cwd=build.CURRENT_DIRECTORY,
+        )
+
     @mock.patch.object(build.platform, "system", return_value="Linux")
     @mock.patch.object(build, "get_vc6_env")
     @mock.patch.object(build.subprocess, "Popen")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,94 @@
+import io
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import build
+
+
+class FakeProcess:
+    def __init__(self):
+        self.stdout = io.StringIO("")
+
+    def poll(self):
+        return None
+
+    def wait(self):
+        return 0
+
+
+class PosixWineInvocationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.build_dir = os.path.join(self.temp_dir.name, "build_vc6")
+        os.makedirs(self.build_dir)
+        self.vc6_env = ("Z:\\vc6\\Lib", "Z:\\vc6\\Include;", "/vc6/bin;/cmake/bin")
+
+    def assert_safe_wine_invocation(self, popen):
+        args, kwargs = popen.call_args
+        command = args[0]
+
+        self.assertIsInstance(command, list)
+        self.assertEqual(command[:3], ["wine", "cmd", "/c"])
+        self.assertEqual(len(command), 4)
+        self.assertNotIn("shell", kwargs)
+        self.assertEqual(kwargs["env"]["WINEDEBUG"], "-all")
+        self.assertEqual(kwargs["env"]["WINEPATH"], self.vc6_env[2])
+        self.assertEqual(kwargs["env"]["LIB"], self.vc6_env[0])
+        self.assertEqual(kwargs["env"]["INCLUDE"], self.vc6_env[1])
+        return command[3]
+
+    @mock.patch.object(build.platform, "system", return_value="Linux")
+    def test_vc6_environment_uses_literal_semicolon_separators(self, _system):
+        with mock.patch.object(build, "CURRENT_DIRECTORY", "/tmp/gta2 re"):
+            lib, include, path = build.get_vc6_env()
+
+        self.assertNotIn(r"\;", include)
+        self.assertNotIn(r"\;", path)
+        self.assertEqual(include.count(";"), 3)
+        self.assertEqual(path.count(";"), 2)
+        self.assertTrue(lib.startswith("Z:"))
+
+    @mock.patch.object(build.platform, "system", return_value="Linux")
+    @mock.patch.object(build, "get_vc6_env")
+    @mock.patch.object(build.subprocess, "Popen")
+    def test_cmake_build_passes_complete_windows_command_as_one_argument(
+        self, popen, get_vc6_env, _system
+    ):
+        popen.return_value = FakeProcess()
+        get_vc6_env.return_value = self.vc6_env
+
+        with mock.patch.object(build, "BUILD_DIRECTORY", self.build_dir), mock.patch.object(
+            build, "BUILD_FOLDER_NAME", self.build_dir
+        ):
+            result = build.build_cmake(reccmp=False, core_count_to_use=2)
+
+        self.assertEqual(result, 0)
+        windows_command = self.assert_safe_wine_invocation(popen)
+        self.assertIn('-G"NMake Makefiles JOM"', windows_command)
+        self.assertIn("cmake --build . --target all -- -j 2", windows_command)
+
+    @mock.patch.object(build.platform, "system", return_value="Linux")
+    @mock.patch.object(build, "get_vc6_env")
+    @mock.patch.object(build.subprocess, "Popen")
+    def test_single_cpp_build_uses_environment_instead_of_shell_exports(
+        self, popen, get_vc6_env, _system
+    ):
+        popen.return_value = FakeProcess()
+        get_vc6_env.return_value = self.vc6_env
+
+        with mock.patch.object(build, "BUILD_DIRECTORY", self.build_dir), mock.patch.object(
+            build, "BUILD_FOLDER_NAME", self.build_dir
+        ), mock.patch.object(build, "CURRENT_DIRECTORY", self.temp_dir.name):
+            result = build.build_single_cpp("Player.cpp")
+
+        self.assertEqual(result, 0)
+        windows_command = self.assert_safe_wine_invocation(popen)
+        self.assertIn("cl.exe @", windows_command)
+        self.assertNotIn("export ", windows_command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- invoke Wine with an argv list instead of malformed shell export concatenation
- pass VC6/Wine variables through a copied subprocess environment
- remove obsolete shell escaping from Wine path lists
- add regression tests for CMake and single-file builds

## Verification
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile build.py tests/test_build.py`
- `python3 Scripts/bin_comp/check_duplicate_globals.py`
- `git diff --check`

A real Wine build was not run because Wine is unavailable on the authoring host.